### PR TITLE
Add on-call to codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,6 @@
 
 # Default rule: anything that doesn't match a more specific rule goes here
 * @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib
+
+# Allows on-call members to respond to dependabot updates to workflows.
+.github/workflows/* @radius-project/on-call @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib


### PR DESCRIPTION
This PR adds the Radius on-call group to the `codeowners` file for the purpose of responding to dependabot updates to the GitHub workflows.