### PR TITLE
Add contributors graphic to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Community members can contribute new Resource Types, Recipes, and Recipe Packs t
 - Contributing Recipe Packs: Coming soon!
 - [Submitting Issues](docs/contributing/contributing-issues.md): This guide provides an overview of how to submit issues related to Resource Types or Recipes.
 
+**Thanks to everyone who has contributed!**
+
+<a href="https://github.com/radius-project/resource-types-contrib/graphs/contributors">
+  <img src="https://contributors-img.web.app/image?repo=radius-project/resource-types-contrib" />
+</a>
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Description
<!--
Brief description of the changes in this PR. Give enough context for the reviewer to understand why the change is being made.
-->

This small change adds a contributors graphic to the README to recognize community members who have made contributions to types and recipes.

Related GitHub Issue: <!--#issue_number or N/A--> N/A

## Testing
<!--
Describe how a reviewer should test these changes.
-->

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] Platform engineer documentation is in README.md
- [x] Developer documentation is the top-level description property
- [x] Example of defining the Resource Type is in the developer documentation
- [x] Example of using the Resource Type with a Container is in the developer documentation
- [x] Verified the output of `rad resource-type show` is correct
- [x] All properties in the Resource Type definition have clear descriptions
- [x] Enum properties have values defined in `enum: []`
- [x] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [x] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [x] Recipes include a results output variable with all read-only properties set
- [x] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [x] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [x] Recipes are idempotent
- [x] Resource types and recipes were tested
