### PR TITLE
Small changes to developer documentation

### DIFF
--- a/Data/mySqlDatabases/mySqlDatabases.yaml
+++ b/Data/mySqlDatabases/mySqlDatabases.yaml
@@ -2,49 +2,53 @@ namespace: Radius.Data
 types:
   mySqlDatabases:
     description: |
-      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database.
+      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database. To deploy a new MySQL database, add the mySqlDatabases resource to the application definition Bicep file.
 
-      To deploy a new MySQL database, add the mySqlDatabases resource to the application definition Bicep file.
-
-      extension Radius
+      extension radius
+      param environment string 
 
       resource myApplication 'Applications.Core/applications@2023-10-01-preview' = { ... }
 
-      param environment string
       resource database 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
+        name: 'database'
         properties: {
           application: myApplication.id
           environment: environment
         }
       }
 
+      To connect your container to the database, create a connection from the Container resource to the database as shown below. 
 
-      For example, to connect to the MySQL database from a container, establish a connection to the database resource as shown below.
-
-      @description('Tag to pull for the application container image.')
-      param tag string = 'latest'
-
-      var port int = 80
       resource frontend 'Applications.Core/containers@2023-10-01-preview' = {
         name: 'frontend'
         properties: {
           application: myApplication.id
           environment: environment
           container: {
-            image: 'your-application-container-using-mysql-database:${tag}'
+            image: 'frontend:1.25'
             ports: {
               web: {
-                containerPort: port
+                containerPort: 8080
               }
             }
           }
           connections: {
-            database: {
+            mysqldb: {
               source: database.id
             }
           }
         }
       }
+
+      The connection automatically injects environment variables into the container for all properties from the database. The environment variables are named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example, the connection name is `mysqldb` so the environment variables will be:
+ 
+      CONNECTION_MYSQLDB_DATABASE
+      CONNECTION_MYSQLDB_USERNAME
+      CONNECTION_MYSQLDB_PASSWORD
+      CONNECTION_MYSQLDB_VERSION
+      CONNECTION_MYSQLDB_HOST
+      CONNECTION_MYSQLDB_PORT
+
     apiVersions:
       '2025-08-01-preview':
         schema:
@@ -65,7 +69,7 @@ types:
             version:
               type: string
               enum: ['5.7', '8.0', '8.4']
-              description: "(Optional) The major MySQL server version in the X.Y format."
+              description: "(Optional) The major MySQL server version in the X.Y format. Assumed to be 8.4 if not specified." 
             password:
               type: string
               description: "(Read-only) The password for connecting to the database."

--- a/Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
+++ b/Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
@@ -51,7 +51,7 @@ resource mySql 'apps/Deployment@v1' = {
         labels: {
           app: context.application.name
           resource: context.resource.name
-          // 'radapp.io/application': context.application == null ? '' : context.application.name
+          'radapp.io/application': context.application == null ? '' : context.application.name
         }
       }
       spec: {
@@ -94,6 +94,8 @@ resource svc 'core/Service@v1' = {
     name: uniqueName
     labels: {
       app: context.application.name
+      resource: context.resource.name
+      'radapp.io/application': context.application == null ? '' : context.application.name
     }
   }
   spec: {


### PR DESCRIPTION
## Description
Updated developer documentation to be aligned with the [Redis PR](https://github.com/radius-project/resource-types-contrib/pull/13/)

## Testing

1. `rad resource-type create -f mySqlDatabases.yaml`
2. `rad resource-type show Radius.Data/mySqlDatabases` and confirm output is as expected
3. `rad bicep publish-extension -f mySqlDatabases.yaml --target radiusResources.tgz` and confirm Intellisense is as expected
4. Copy examples from rad resource-type show into a Bicep file and confirm they compile
