### PR TITLE
Added guidance instructing developer documentation to be written in Markdown 

### DIFF
--- a/docs/contributing/contributing-resource-types-recipes.md
+++ b/docs/contributing/contributing-resource-types-recipes.md
@@ -180,7 +180,7 @@ The following guidelines should be followed when contributing new Resource Types
 Each Resource Type has two types of documentation written specifically for developers, and separately, for platform engineers.
 
 ### Developers
-Developer documentation is embedded in the Resource Type definition. Each Resource Type definition must have documentation on how and when to use the resource in the top-level description property. Developer documentation is embedded in the Resource Type definition. Each Resource Type definition must have documentation on how and when to use the resource in the top-level description property. When writing developer documentation, use Markdown. This is especially important for code blocks which must be quoted using triple backquotes. Output from `rad resource-type show` is shown in text only, but the Radius Dashboard formats the Markdown property including the ability to single-click copy code blocks.
+Developer documentation is embedded in the Resource Type definition. Each Resource Type definition must have documentation on how and when to use the resource in the top-level description property. When writing developer documentation, use Markdown. This is especially important for code blocks which must be quoted using triple backquotes. Output from `rad resource-type show` is shown in text only, but the Radius Dashboard formats the Markdown property including the ability to single-click copy code blocks.
 
 Each property must also include:
  - The overall description of the property including example values.


### PR DESCRIPTION
Now that the Radius Dashboard treats resource type documentation as Markdown, this is a small update to the contributing docs to use Markdown.