### PR TITLE
Correcting bicep example in yaml file.

### DIFF
--- a/Security/secrets/secrets.yaml
+++ b/Security/secrets/secrets.yaml
@@ -12,9 +12,12 @@ types:
           properties: {
             environment: environment
             application: myApplication.id
-            data:
-              myToken:
+            data: {
+              myToken: {
                 value: myTokenValue
+                encoding: 'base64'   //optional
+              }
+            }
           }
         }
 


### PR DESCRIPTION
This pull request updates the example in the `data` property in the `Security/secrets/secrets.yaml` file to be correctly formatted in bicep.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] Platform engineer documentation is in README.md
- [x] Developer documentation is the top-level description property
- [x] Example of defining the Resource Type is in the developer documentation
- [x] Example of using the Resource Type with a Container is in the developer documentation
- [x] Verified the output of `rad resource-type show` is correct
- [x] All properties in the Resource Type definition have clear descriptions
- [x] Enum properties have values defined in `enum: []`
- [x] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [x] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [x] Recipes include a results output variable with all read-only properties set
- [x] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [x] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [x] Recipes are idempotent
- [x] Resource types and recipes were tested
