### PR TITLE
Ignore special characters for password generation in Terraform Recipe

### DIFF
--- a/Data/postgreSqlDatabases/recipes/kubernetes/terraform/main.tf
+++ b/Data/postgreSqlDatabases/recipes/kubernetes/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
 }
 
 variable "context" {
-  description = "This variable contains Radius recipe context."
+  description = "This variable contains Radius Recipe context."
   type = any
 }
 
@@ -37,7 +37,8 @@ locals {
 }
 
 resource "random_password" "password" {
-  length           = 16
+  length  = 16
+  special = false
 }
 
 resource "kubernetes_deployment" "postgresql" {


### PR DESCRIPTION
## Description
<!--
Brief description of the changes in this PR. Give enough context for the reviewer to understand why the change is being made.
-->
This PR adds an option to ignore special characters for password generation in Terraform Recipe. This was creating issues where passwords have % and other special characters

Related GitHub Issue: <!--#issue_number or N/A-->

## Testing
<!--
Describe how a reviewer should test these changes.
-->

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] Platform engineer documentation is in README.md
- [x] Developer documentation is the top-level description property
- [x] Example of defining the Resource Type is in the developer documentation
- [x] Example of using the Resource Type with a Container is in the developer documentation
- [x] Verified the output of `rad resource-type show` is correct
- [x] All properties in the Resource Type definition have clear descriptions
- [x] Enum properties have values defined in `enum: []`
- [x] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [x] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [x] Recipes include a results output variable with all read-only properties set
- [x] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [x] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [x] Recipes are idempotent
- [x] Resource types and recipes were tested
