### PR TITLE
fix: use double asterisks for paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,5 @@
 * @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib
 
 # Allows on-call members to respond to dependabot updates to workflows.
-.github/* @radius-project/on-call @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib
-.devcontainer/* @radius-project/on-call @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib
+.github/** @radius-project/on-call @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib
+.devcontainer/** @radius-project/on-call @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file. The change expands the ownership patterns to include all files and subdirectories within `.github` and `.devcontainer`, ensuring that the specified teams are assigned ownership for any files within these directories.
