### PR TITLE
Add `Radius.Compute/containerImages` resource type and Terraform recipe (WIP)

### DIFF
--- a/Compute/containerImages/README.md
+++ b/Compute/containerImages/README.md
@@ -1,0 +1,92 @@
+## Overview
+
+The Radius.Compute/containerImages Resource Type builds a container image from source and pushes it to a remote container registry (e.g., ghcr.io). It is always part of a Radius Application.
+
+This resource type is designed for **local development workflows** where the source code is available on the Kubernetes node filesystem (e.g., via kind `extraMounts` or k3d `-v` flags). It uses [BuildKit](https://github.com/moby/buildkit) to build and push the image inside a Kubernetes Job.
+
+Developer documentation is embedded in the Resource Type definition YAML file. Developer documentation is accessible via `rad resource-type show Radius.Compute/containerImages`.
+
+## Architecture
+
+```
+Host machine                          Kubernetes node
+┌─────────────────────┐              ┌──────────────────────────────┐
+│ ~/dev/myapp/        │  extraMount  │ /app/myapp/                  │
+│   Dockerfile        │ ──────────►  │   Dockerfile                 │
+│   src/              │              │   src/                       │
+└─────────────────────┘              │                              │
+                                     │  Build Job pod:              │
+                                     │  ┌────────────────────────┐  │
+                                     │  │ BuildKit               │  │
+                                     │  │  hostPath: /app/myapp  │  │
+                                     │  │  → builds image        │  │
+                                     │  │  → pushes to registry  │  │
+                                     │  │  (creds from recipe    │  │
+                                     │  │   parameters)          │  │
+                                     │  └────────────────────────┘  │
+                                     └──────────────────────────────┘
+```
+
+## Recipes
+
+| Platform | IaC Language | Recipe Name | Stage |
+|---|---|---|---|
+| Kubernetes | Terraform | main.tf | Alpha |
+
+## Recipe Parameters
+
+Registry credentials are configured by the platform engineer when registering the recipe:
+
+```bash
+rad recipe register default \
+  --resource-type Radius.Compute/containerImages \
+  --template-kind terraform \
+  --template-path "git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform" \
+  --parameters ghcr_username=YOUR_USERNAME \
+  --parameters ghcr_token=YOUR_PAT
+```
+
+| Parameter | Default | Description |
+|---|---|---|
+| `ghcr_server` | `ghcr.io` | Registry server address |
+| `ghcr_username` | `""` | Registry username |
+| `ghcr_token` | `""` | Registry token or PAT (sensitive) |
+
+## Recipe Input Properties
+
+| Radius Property | Description |
+|---|---|
+| `image` | Full image reference including registry (e.g., `ghcr.io/myorg/myapp:latest`). Must be lowercase. |
+| `build.context` | Host path to source directory (must be available on the Kubernetes node) |
+| `build.dockerfile` | Dockerfile path relative to build context (default: `Dockerfile`) |
+| `registry.server` | (Optional) Override registry server from recipe parameters |
+| `registry.username` | (Optional) Override registry username from recipe parameters |
+| `registry.token` | (Optional) Override registry token from recipe parameters |
+
+## Recipe Output Properties
+
+There are no output properties that need to be set by the Recipe.
+
+## Limitations
+
+- **Local development only**: Requires `hostPath` access to source code on the Kubernetes node. This works with kind (`extraMounts`), k3d (`-v` flags), Docker Desktop, and similar local Kubernetes distributions. It does not work with remote clusters unless the source is available on the node filesystem.
+
+- **Privileged container**: BuildKit requires `securityContext.privileged: true`. Clusters with restrictive PodSecurityAdmission policies may block this. Consider using [BuildKit rootless mode](https://github.com/moby/buildkit/blob/master/docs/rootless.md) for environments that do not allow privileged containers.
+
+- **Single-node clusters**: The Job is scheduled on any node. In multi-node clusters, the `hostPath` mount may not be available on the scheduled node. Use a single-node cluster or node affinity to ensure correct scheduling.
+
+- **RBAC**: The `dynamic-rp` service account requires `batch/jobs` permissions. This must be configured by the platform engineer:
+
+  ```bash
+  kubectl patch clusterrole dynamic-rp --type=json -p='[
+    {
+      "op": "add",
+      "path": "/rules/-",
+      "value": {
+        "apiGroups": ["batch"],
+        "resources": ["jobs", "jobs/status"],
+        "verbs": ["create", "delete", "get", "list", "patch", "update", "watch"]
+      }
+    }
+  ]'
+  ```

--- a/Compute/containerImages/containerImages.yaml
+++ b/Compute/containerImages/containerImages.yaml
@@ -1,0 +1,109 @@
+namespace: Radius.Compute
+types:
+  containerImages:
+    description: |
+      The Radius.Compute/containerImages Resource Type builds a container image from source and pushes it to a container registry. It is always part of a Radius Application.
+
+      This resource type is designed for local development workflows where the source code is available on the Kubernetes node filesystem (e.g., via kind `extraMounts` or k3d `-v` flags). It uses BuildKit to build and push the image.
+
+      To build and push a container image, add a containerImages resource to your application definition Bicep file:
+
+        extension radius
+        extension containerImages
+
+        param environment string
+
+        resource myApp 'Radius.Core/applications@2025-08-01-preview' = {
+          name: 'myApp'
+          properties: {
+            environment: environment
+          }
+        }
+
+        resource myImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+          name: 'myImage'
+          properties: {
+            environment: environment
+            application: myApp.id
+            image: 'ghcr.io/myorg/myapp:latest'
+            build: {
+              context: '/app/src/myapp'
+            }
+          }
+        }
+
+      Registry credentials are configured by the platform engineer when registering the recipe. Developers do not need to manage credentials.
+
+      To reference the built image in a Container resource:
+
+        resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+          name: 'myContainer'
+          properties: {
+            environment: environment
+            application: myApp.id
+            containers: {
+              app: {
+                image: myImage.properties.image
+                ports: {
+                  web: {
+                    containerPort: 3000
+                  }
+                }
+              }
+            }
+          }
+        }
+
+      Prerequisites:
+
+      1. The Kubernetes cluster must have the source directory available on the node. For kind, use `extraMounts`. For k3d, use `-v` flags.
+
+      2. Registry credentials must be configured as recipe parameters when registering the recipe:
+
+        rad recipe register default --resource-type Radius.Compute/containerImages --template-kind terraform --template-path git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform --parameters ghcr_username=USERNAME --parameters ghcr_token=PAT
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
+            application:
+              type: string
+              description: (Required) The Radius Application ID. `myApplication.id` for example.
+            image:
+              type: string
+              description: (Required) The full container image reference including registry, repository, and tag. `ghcr.io/myorg/myapp:latest` for example. Must be lowercase.
+            build:
+              type: object
+              description: (Required) Build configuration for the container image.
+              properties:
+                context:
+                  type: string
+                  description: (Required) The path to the build context directory on the Kubernetes node. This must be a path available on the node, for example via kind extraMounts or k3d volume flags. `/app/src/myapp` for example.
+                dockerfile:
+                  type: string
+                  description: (Optional) The path to the Dockerfile relative to the build context. If not specified, `Dockerfile` is assumed.
+              required:
+                - context
+            registry:
+              type: object
+              description: (Optional) Registry authentication overrides. If not specified, the recipe uses credentials configured by the platform engineer as recipe parameters.
+              properties:
+                server:
+                  type: string
+                  description: (Optional) The registry server address. If not specified, `ghcr.io` is assumed.
+                username:
+                  type: string
+                  description: (Optional) The registry username.
+                token:
+                  type: string
+                  description: (Optional) The registry token or PAT.
+                  x-radius-sensitive: true
+          required:
+            - environment
+            - application
+            - image
+            - build

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -9,14 +9,8 @@ terraform {
 }
 
 provider "docker" {
-  # Uses the Docker socket mounted into the dynamic-rp pod.
-  # Enabled via: rad install kubernetes --set dynamicrp.docker.enabled=true
-
-  registry_auth {
-    address  = local.registry_server
-    username = local.registry_username
-    password = local.registry_token
-  }
+  # Uses credentials from ~/.docker/config.json (set via `docker login`
+  # on the dynamic-rp pod by the platform engineer).
 }
 
 # ── Locals ───────────────────────────────────────────────────────────
@@ -30,11 +24,6 @@ locals {
   image         = local.properties.image
   build_context = local.properties.build.context
   dockerfile    = try(local.properties.build.dockerfile, "Dockerfile")
-
-  # Registry credentials from resource properties or recipe parameters
-  registry_server   = try(local.properties.registry.server, var.ghcr_server)
-  registry_username = try(local.properties.registry.username, var.ghcr_username)
-  registry_token    = try(local.properties.registry.token, var.ghcr_token)
 }
 
 # ── Build and push ───────────────────────────────────────────────────

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -1,15 +1,22 @@
 terraform {
   required_version = ">= 1.5"
   required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.37.1"
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = ">= 3.0"
     }
   }
 }
 
-provider "kubernetes" {
-  config_path = ""
+provider "docker" {
+  # Uses the Docker socket mounted into the dynamic-rp pod.
+  # Enabled via: rad install kubernetes --set dynamicrp.docker.enabled=true
+
+  registry_auth {
+    address  = local.registry_server
+    username = local.registry_username
+    password = local.registry_token
+  }
 }
 
 # ── Locals ───────────────────────────────────────────────────────────
@@ -24,162 +31,42 @@ locals {
   build_context = local.properties.build.context
   dockerfile    = try(local.properties.build.dockerfile, "Dockerfile")
 
-  # Registry credentials: use resource properties if provided, fall back to recipe parameters
+  # Registry credentials from resource properties or recipe parameters
   registry_server   = try(local.properties.registry.server, var.ghcr_server)
   registry_username = try(local.properties.registry.username, var.ghcr_username)
   registry_token    = try(local.properties.registry.token, var.ghcr_token)
-  has_credentials   = local.registry_username != "" && local.registry_token != ""
+}
 
-  docker_config_json = jsonencode({
-    auths = {
-      (local.registry_server) = {
-        username = local.registry_username
-        password = local.registry_token
-      }
-    }
-  })
+# ── Build and push ───────────────────────────────────────────────────
+# Uses the Docker daemon (via mounted socket) to build and push.
+# No Kubernetes Job, no privileged containers, no RBAC patches needed.
 
-  environment_segments = try(split("/", local.properties.environment), [])
-  environment_label    = length(local.environment_segments) > 0 ? element(local.environment_segments, length(local.environment_segments) - 1) : ""
+resource "docker_image" "build" {
+  name = local.image
 
-  # Hash of build inputs to ensure Job name changes when inputs change.
-  # Kubernetes Jobs are immutable — this forces recreation on re-deploy.
-  build_hash = substr(md5(jsonencode({
-    image      = local.image
+  build {
     context    = local.build_context
     dockerfile = local.dockerfile
-    server     = local.registry_server
-    username   = local.registry_username
-    token      = local.registry_token
-  })), 0, 8)
+  }
 
-  labels = {
-    "radapp.io/resource"    = local.resource_name
-    "radapp.io/environment" = local.environment_label
-    "radapp.io/application" = try(var.context.application.name, "")
+  triggers = {
+    # Rebuild when source directory contents change
+    dir_sha1 = sha1(join("", [
+      for f in fileset(local.build_context, "**") :
+      filesha1("${local.build_context}/${f}")
+    ]))
   }
 }
 
-# ── Registry credentials secret ──────────────────────────────────────
-# Created from recipe parameters configured by the platform engineer.
-
-resource "kubernetes_secret_v1" "docker_config" {
-  count = local.has_credentials ? 1 : 0
-
-  metadata {
-    name      = "${local.normalized_name}-registry"
-    namespace = local.namespace
-    labels    = local.labels
-  }
-
-  type = "kubernetes.io/dockerconfigjson"
-  data = {
-    ".dockerconfigjson" = local.docker_config_json
-  }
-}
-
-# ── Build Job ────────────────────────────────────────────────────────
-# Mounts the source directory from the host via hostPath, then BuildKit
-# builds and pushes the image to the remote registry.
-#
-# Limitations:
-# - Requires hostPath access (kind extraMounts / k3d -v)
-# - Requires privileged container (for BuildKit)
-
-resource "kubernetes_job_v1" "build" {
-  metadata {
-    name      = "${local.normalized_name}-build-${local.build_hash}"
-    namespace = local.namespace
-    labels    = local.labels
-  }
-
-  spec {
-    backoff_limit              = 3
-    ttl_seconds_after_finished = 600
-
-    template {
-      metadata {
-        labels = local.labels
-      }
-
-      spec {
-        restart_policy = "Never"
-
-        container {
-          name  = "build-and-push"
-          image = "moby/buildkit:latest"
-
-          command = [
-            "buildctl-daemonless.sh",
-            "build",
-            "--frontend=dockerfile.v0",
-            "--local=context=/workspace",
-            "--local=dockerfile=/workspace",
-            "--opt=filename=${local.dockerfile}",
-            "--output=type=image,name=${local.image},push=true",
-          ]
-
-          volume_mount {
-            name       = "source"
-            mount_path = "/workspace"
-            read_only  = true
-          }
-
-          dynamic "volume_mount" {
-            for_each = local.has_credentials ? [1] : []
-            content {
-              name       = "docker-config"
-              mount_path = "/root/.docker"
-              read_only  = true
-            }
-          }
-
-          security_context {
-            privileged = true
-          }
-        }
-
-        volume {
-          name = "source"
-          host_path {
-            path = local.build_context
-            type = "Directory"
-          }
-        }
-
-        dynamic "volume" {
-          for_each = local.has_credentials ? [1] : []
-          content {
-            name = "docker-config"
-            secret {
-              secret_name = kubernetes_secret_v1.docker_config[0].metadata[0].name
-              items {
-                key  = ".dockerconfigjson"
-                path = "config.json"
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  wait_for_completion = true
-
-  timeouts {
-    create = "10m"
-  }
-
-  depends_on = [kubernetes_secret_v1.docker_config]
+resource "docker_registry_image" "push" {
+  name          = docker_image.build.name
+  keep_remotely = true
 }
 
 # ── Outputs ──────────────────────────────────────────────────────────
 
 output "result" {
   value = {
-    resources = concat(
-      ["/planes/kubernetes/local/namespaces/${local.namespace}/providers/batch/Job/${local.normalized_name}-build-${local.build_hash}"],
-      local.has_credentials ? ["/planes/kubernetes/local/namespaces/${local.namespace}/providers/core/Secret/${local.normalized_name}-registry"] : []
-    )
+    resources = []
   }
 }

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 1.5"
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
+      version = ">= 2.37.1"
     }
   }
 }
@@ -41,6 +42,17 @@ locals {
   environment_segments = try(split("/", local.properties.environment), [])
   environment_label    = length(local.environment_segments) > 0 ? element(local.environment_segments, length(local.environment_segments) - 1) : ""
 
+  # Hash of build inputs to ensure Job name changes when inputs change.
+  # Kubernetes Jobs are immutable — this forces recreation on re-deploy.
+  build_hash = substr(md5(jsonencode({
+    image      = local.image
+    context    = local.build_context
+    dockerfile = local.dockerfile
+    server     = local.registry_server
+    username   = local.registry_username
+    token      = local.registry_token
+  })), 0, 8)
+
   labels = {
     "radapp.io/resource"    = local.resource_name
     "radapp.io/environment" = local.environment_label
@@ -76,7 +88,7 @@ resource "kubernetes_secret_v1" "docker_config" {
 
 resource "kubernetes_job_v1" "build" {
   metadata {
-    name      = "${local.normalized_name}-build"
+    name      = "${local.normalized_name}-build-${local.build_hash}"
     namespace = local.namespace
     labels    = local.labels
   }
@@ -166,7 +178,7 @@ resource "kubernetes_job_v1" "build" {
 output "result" {
   value = {
     resources = concat(
-      ["/planes/kubernetes/local/namespaces/${local.namespace}/providers/batch/Job/${local.normalized_name}-build"],
+      ["/planes/kubernetes/local/namespaces/${local.namespace}/providers/batch/Job/${local.normalized_name}-build-${local.build_hash}"],
       local.has_credentials ? ["/planes/kubernetes/local/namespaces/${local.namespace}/providers/core/Secret/${local.normalized_name}-registry"] : []
     )
   }

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -1,0 +1,173 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = ""
+}
+
+# ── Locals ───────────────────────────────────────────────────────────
+
+locals {
+  resource_name   = var.context.resource.name
+  namespace       = var.context.runtime.kubernetes.namespace
+  normalized_name = local.resource_name
+
+  properties    = try(var.context.resource.properties, {})
+  image         = local.properties.image
+  build_context = local.properties.build.context
+  dockerfile    = try(local.properties.build.dockerfile, "Dockerfile")
+
+  # Registry credentials: use resource properties if provided, fall back to recipe parameters
+  registry_server   = try(local.properties.registry.server, var.ghcr_server)
+  registry_username = try(local.properties.registry.username, var.ghcr_username)
+  registry_token    = try(local.properties.registry.token, var.ghcr_token)
+  has_credentials   = local.registry_username != "" && local.registry_token != ""
+
+  docker_config_json = jsonencode({
+    auths = {
+      (local.registry_server) = {
+        username = local.registry_username
+        password = local.registry_token
+      }
+    }
+  })
+
+  environment_segments = try(split("/", local.properties.environment), [])
+  environment_label    = length(local.environment_segments) > 0 ? element(local.environment_segments, length(local.environment_segments) - 1) : ""
+
+  labels = {
+    "radapp.io/resource"    = local.resource_name
+    "radapp.io/environment" = local.environment_label
+    "radapp.io/application" = try(var.context.application.name, "")
+  }
+}
+
+# ── Registry credentials secret ──────────────────────────────────────
+# Created from recipe parameters configured by the platform engineer.
+
+resource "kubernetes_secret_v1" "docker_config" {
+  count = local.has_credentials ? 1 : 0
+
+  metadata {
+    name      = "${local.normalized_name}-registry"
+    namespace = local.namespace
+    labels    = local.labels
+  }
+
+  type = "kubernetes.io/dockerconfigjson"
+  data = {
+    ".dockerconfigjson" = local.docker_config_json
+  }
+}
+
+# ── Build Job ────────────────────────────────────────────────────────
+# Mounts the source directory from the host via hostPath, then BuildKit
+# builds and pushes the image to the remote registry.
+#
+# Limitations:
+# - Requires hostPath access (kind extraMounts / k3d -v)
+# - Requires privileged container (for BuildKit)
+
+resource "kubernetes_job_v1" "build" {
+  metadata {
+    name      = "${local.normalized_name}-build"
+    namespace = local.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    backoff_limit              = 3
+    ttl_seconds_after_finished = 600
+
+    template {
+      metadata {
+        labels = local.labels
+      }
+
+      spec {
+        restart_policy = "Never"
+
+        container {
+          name  = "build-and-push"
+          image = "moby/buildkit:latest"
+
+          command = [
+            "buildctl-daemonless.sh",
+            "build",
+            "--frontend=dockerfile.v0",
+            "--local=context=/workspace",
+            "--local=dockerfile=/workspace",
+            "--opt=filename=${local.dockerfile}",
+            "--output=type=image,name=${local.image},push=true",
+          ]
+
+          volume_mount {
+            name       = "source"
+            mount_path = "/workspace"
+            read_only  = true
+          }
+
+          dynamic "volume_mount" {
+            for_each = local.has_credentials ? [1] : []
+            content {
+              name       = "docker-config"
+              mount_path = "/root/.docker"
+              read_only  = true
+            }
+          }
+
+          security_context {
+            privileged = true
+          }
+        }
+
+        volume {
+          name = "source"
+          host_path {
+            path = local.build_context
+            type = "Directory"
+          }
+        }
+
+        dynamic "volume" {
+          for_each = local.has_credentials ? [1] : []
+          content {
+            name = "docker-config"
+            secret {
+              secret_name = kubernetes_secret_v1.docker_config[0].metadata[0].name
+              items {
+                key  = ".dockerconfigjson"
+                path = "config.json"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "10m"
+  }
+
+  depends_on = [kubernetes_secret_v1.docker_config]
+}
+
+# ── Outputs ──────────────────────────────────────────────────────────
+
+output "result" {
+  value = {
+    resources = concat(
+      ["/planes/kubernetes/local/namespaces/${local.namespace}/providers/batch/Job/${local.normalized_name}-build"],
+      local.has_credentials ? ["/planes/kubernetes/local/namespaces/${local.namespace}/providers/core/Secret/${local.normalized_name}-registry"] : []
+    )
+  }
+}

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -9,8 +9,12 @@ terraform {
 }
 
 provider "docker" {
-  # Uses credentials from ~/.docker/config.json (set via `docker login`
+  # Reads credentials from ~/.docker/config.json (set via `docker login`
   # on the dynamic-rp pod by the platform engineer).
+  registry_auth {
+    address     = var.registry_server
+    config_file = pathexpand("~/.docker/config.json")
+  }
 }
 
 # ── Locals ───────────────────────────────────────────────────────────

--- a/Compute/containerImages/recipes/kubernetes/terraform/var.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/var.tf
@@ -1,0 +1,23 @@
+variable "context" {
+  description = "This variable contains Radius recipe context."
+  type        = any
+}
+
+variable "ghcr_server" {
+  description = "Registry server (e.g., ghcr.io). Set via recipe parameters when registering the recipe."
+  type        = string
+  default     = "ghcr.io"
+}
+
+variable "ghcr_username" {
+  description = "Registry username. Set via recipe parameters when registering the recipe."
+  type        = string
+  default     = ""
+}
+
+variable "ghcr_token" {
+  description = "Registry token/PAT. Set via recipe parameters when registering the recipe."
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/Compute/containerImages/recipes/kubernetes/terraform/var.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/var.tf
@@ -2,22 +2,3 @@ variable "context" {
   description = "This variable contains Radius recipe context."
   type        = any
 }
-
-variable "ghcr_server" {
-  description = "Registry server (e.g., ghcr.io). Set via recipe parameters when registering the recipe."
-  type        = string
-  default     = "ghcr.io"
-}
-
-variable "ghcr_username" {
-  description = "Registry username. Set via recipe parameters when registering the recipe."
-  type        = string
-  default     = ""
-}
-
-variable "ghcr_token" {
-  description = "Registry token/PAT. Set via recipe parameters when registering the recipe."
-  type        = string
-  default     = ""
-  sensitive   = true
-}

--- a/Compute/containerImages/recipes/kubernetes/terraform/var.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/var.tf
@@ -2,3 +2,9 @@ variable "context" {
   description = "This variable contains Radius recipe context."
   type        = any
 }
+
+variable "registry_server" {
+  description = "Registry server address for authentication. Defaults to ghcr.io."
+  type        = string
+  default     = "ghcr.io"
+}

--- a/Compute/containerImages/test/app.bicep
+++ b/Compute/containerImages/test/app.bicep
@@ -1,0 +1,47 @@
+extension radius
+extension containerImages
+extension containers
+
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'containerimages-testapp'
+  properties: {
+    environment: environment
+  }
+}
+
+resource testImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'test-image'
+  properties: {
+    environment: environment
+    application: app.id
+    image: 'ghcr.io/radius-project/samples/demo:latest'
+    build: {
+      context: '/app/test'
+    }
+  }
+}
+
+resource testContainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'test-container'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      app: {
+        image: testImage.properties.image
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      image: {
+        source: testImage.id
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
<!--
Brief description of the changes in this PR. Give enough context for the reviewer to understand why the change is being made.
-->

NOTE: This will fail because this is a specialized recipe for dynamic-rp

Related GitHub Issue: <!--#issue_number or N/A-->

## Testing
<!--
Describe how a reviewer should test these changes.
-->

## Contributor Checklist

- [ ] File names follow naming conventions and folder structure
- [ ] Platform engineer documentation is in README.md
- [ ] Developer documentation is the top-level description property
- [ ] Example of defining the Resource Type is in the developer documentation
- [ ] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [ ] All properties in the Resource Type definition have clear descriptions
- [ ] Enum properties have values defined in `enum: []`
- [ ] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [ ] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [ ] Recipes include a results output variable with all read-only properties set
- [ ] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [ ] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [ ] Recipes are provided for at least one platform
- [ ] Recipes handle secrets securely
- [ ] Recipes are idempotent
- [ ] Resource types and recipes were tested
