### PR TITLE
Remove deprecated github.copilot-chat extension from recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "davidanson.vscode-markdownlint",
     "github.copilot",
-		"github.copilot-chat",
     "github.vscode-pull-request-github",
     "github.vscode-github-actions",
     "hashicorp.terraform",


### PR DESCRIPTION
The `github.copilot-chat` extension has been deprecated and merged into the `github.copilot` extension. This PR removes it from the recommended extensions list in `.vscode/extensions.json`.