### PR TITLE
Handle missing container connections in recipe

### DIFF
--- a/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+++ b/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
@@ -36,8 +36,8 @@ var labels = {
 }
 
 // Extract connection data from linked resources (merged with resource properties)
-var resourceConnections = context.resource.connections ?? {}
-var connectionDefinitions = context.resource.properties.connections ?? {}
+var resourceConnections = context.resource.?connections ?? {}
+var connectionDefinitions = resourceProperties.?connections ?? {}
 
 // Properties to exclude from connection environment variables
 var excludedProperties = ['recipe', 'status', 'provisioningState']


### PR DESCRIPTION
## Description

Fixes #91.

The Kubernetes container recipe assumed that both `context.resource.connections` and `context.resource.properties.connections` always exist. However, `connections` is optional for `Radius.Compute/containers`, so deploying a container without a `connections` block failed during recipe template validation.

This PR updates the recipe to use optional property access for `connections` and to read connection definitions from the existing `resourceProperties` variable. When no connections are defined, the recipe now falls back to an empty object and can deploy containers that do not declare connected resources.

Related GitHub Issue: #91

## Testing

Validate with the repro from #91:

1. Publish and register the Kubernetes container recipe.
2. Deploy a `Radius.Compute/containers` resource that omits the `connections` property.
3. Confirm the deployment succeeds instead of failing with `The language expression property 'connections' doesn't exist`.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [ ] Platform engineer documentation is in README.md
- [ ] Developer documentation is the top-level description property
- [ ] Example of defining the Resource Type is in the developer documentation
- [ ] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [ ] All properties in the Resource Type definition have clear descriptions
- [ ] Enum properties have values defined in `enum: []`
- [ ] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [ ] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [ ] Recipes include a results output variable with all read-only properties set
- [ ] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [x] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [x] Recipes are idempotent
- [ ] Resource types and recipes were tested
