### PR TITLE
Add Radius maintainers as CODEOWNERS for default types

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,10 @@
 # Allows on-call members to respond to dependabot updates to workflows.
 .github/** @radius-project/on-call @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib
 .devcontainer/** @radius-project/on-call @radius-project/maintainers-resource-types-contrib @radius-project/approvers-resource-types-contrib
+
+# Default registration and embed infrastructure changes require Radius maintainer
+# approval to ensure only reviewed types are embedded into the Radius binary.
+/defaults.yaml @radius-project/radius-maintainers
+/manifests.go @radius-project/radius-maintainers
+/manifests_gen.go @radius-project/radius-maintainers
+/cmd/gen-embed/ @radius-project/radius-maintainers


### PR DESCRIPTION
## Summary

Add `@radius-project/radius-maintainers` as required CODEOWNERS reviewers for `defaults.yaml` and Go module embed infrastructure files.

Implements the security recommendation from the https://github.com/radius-project/radius/blob/main/eng/design-notes/extensibility/2026-04-automated-default-resource-type-registration.md#alternative-approach-2-ci-diff-report-and-codeowners

## Why

`defaults.yaml` controls which resource types are embedded into the Radius binary and registered at startup. Since this file lives in `resource-types-contrib` (which may have a broader set of contributors), Radius maintainers should be required reviewers to ensure only reviewed types become defaults.

## Changes

Added CODEOWNERS rules requiring `@radius-project/radius-maintainers` approval for:

| File | Reason |
|---|---|
| `/defaults.yaml` | Controls which types are registered by default in Radius |
| `/manifests.go` | Contains `//go:generate` directive |
| `/manifests_gen.go` | Generated embed directives |
| `/cmd/gen-embed/` | Code generator |