### PR TITLE
Add workflow to notify Radius repo on contrib updates

### DIFF
--- a/.github/workflows/notify-radius.yaml
+++ b/.github/workflows/notify-radius.yaml
@@ -1,0 +1,84 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+---
+name: notify-radius
+
+# Fires a `repository_dispatch` event to radius-project/radius whenever
+# resource type manifests change on `main`. The Radius repo responds by opening
+# a PR that runs `make update-resource-types`, which refreshes the manifest
+# copies committed under `deploy/manifest/built-in-providers/`. Merging that PR
+# triggers the existing `build-and-push-bicep-types` job in build.yaml, which
+# dispatches to radius-publisher to republish `radius:latest` with the updated
+# types.
+#
+# End-to-end flow:
+#   1. This workflow fires repository_dispatch on push to main
+#   2. Radius repo's contrib-update-resource-types.yaml receives it
+#   3. Opens a PR to refresh manifest copies via make update-resource-types
+#   4. Human merges the PR
+#   5. Push to main triggers build.yaml -> radius-publisher -> biceptypes.azurecr.io
+#
+# Note: only resource types listed in the Radius repo's
+# deploy/manifest/defaults.yaml are included in the unified extension.
+# If a new namespace folder is added here but not added to defaults.yaml,
+# the dispatch will fire but make update-resource-types will find no changes
+# and no PR will be opened. The new types only appear in the extension when
+# someone adds them to defaults.yaml in the Radius repo.
+#
+# See the design note in the radius repo:
+#   eng/design-notes/extensibility/2026-05-unified-bicep-extension-publishing.md
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # Trigger on any YAML change that could be a resource type manifest.
+      # Excludes .github/ and docs/ which contain non-manifest YAML files.
+      # This avoids hardcoding namespace folder names (Compute/, Data/, etc.)
+      # so new top-level namespace folders are automatically covered.
+      - "**/*.yaml"
+      - "**/*.yml"
+      - "!.github/**"
+      - "!docs/**"
+  # workflow_dispatch: # Enable during development for manual testing
+
+permissions: {}
+
+concurrency:
+  group: notify-radius
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch resource-types-contrib-updated
+    if: github.repository == 'radius-project/resource-types-contrib'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Send repository_dispatch to radius-project/radius
+        # Fires a repository_dispatch event that the Radius repo's
+        # contrib-update-resource-types.yaml workflow listens for.
+        # The payload includes the commit SHA for traceability in the
+        # automated PR's commit message and body. Note: the SHA is
+        # informational only -- the Radius workflow always fetches
+        # the latest version via 'go get ...@latest'.
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          repository: radius-project/radius
+          event-type: resource-types-contrib-updated
+          client-payload: |
+            {
+              "contrib_ref": "${{ github.sha }}",
+              "contrib_repo": "${{ github.repository }}",
+              "actor": "${{ github.actor }}"
+            }
+
+      - name: Summarize
+        # Write a summary to the GitHub Actions UI for visibility.
+        run: |
+          {
+            echo "## Notified radius-project/radius"
+            echo "* Event: \`resource-types-contrib-updated\`"
+            echo "* Commit: \`${{ github.sha }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/notify-radius.yaml
+++ b/.github/workflows/notify-radius.yaml
@@ -55,6 +55,22 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
+      - name: Generate App Token
+        # Uses a GitHub App token instead of a PAT so that the dispatch event
+        # is sent with scoped, auditable credentials. The app must be installed
+        # on the target repo (radius-project/radius) with contents:write to
+        # trigger repository_dispatch.
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RESOURCE_TYPES_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RESOURCE_TYPES_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            radius
+          permission-metadata: read
+          permission-contents: write
+
       - name: Send repository_dispatch to radius-project/radius
         # Fires a repository_dispatch event that the Radius repo's
         # contrib-update-resource-types.yaml workflow listens for.
@@ -64,7 +80,7 @@ jobs:
         # the latest version via 'go get ...@latest'.
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
-          token: ${{ secrets.GH_RAD_CI_BOT_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: radius-project/radius
           event-type: resource-types-contrib-updated
           client-payload: |


### PR DESCRIPTION
## Overview

Today the `radius` Bicep extension published to `biceptypes.azurecr.io` includes core namespaces (`Applications.Core`, `Applications.Dapr`, etc.) and, with [radius#11915](https://github.com/radius-project/radius/pull/11915), also includes contrib resource types (`Radius.Compute`, `Radius.Data`, `Radius.Security`). However, when resource type manifests change in this repo, there is no automation to notify the Radius repo so it can refresh its manifest copies and republish the extension.

This PR adds a workflow that fires a `repository_dispatch` event to `radius-project/radius` whenever resource type manifests are updated on `main`, triggering the Radius repo's automated sync and publish pipeline.

## End-to-end flow

```
resource-types-contrib merges to main
  |
  +--> notify-radius.yaml (this PR) fires repository_dispatch
         |
         +--> contrib-update-resource-types.yaml (radius repo) receives dispatch
                |
                +--> Runs 'make update-resource-types' to refresh manifest copies
                +--> Opens/updates PR on bot/update-resource-types branch
                       |
                       +--> Human reviews and merges the PR
                              |
                              +--> Push to main triggers build.yaml's existing
                                   build-and-push-bicep-types job
                                     |
                                     +--> Dispatches to radius-publisher
                                     +--> Publishes radius:latest to biceptypes.azurecr.io
```

## What this PR adds

### `notify-radius.yaml`

**Trigger:** Push to `main` touching any YAML file, excluding `.github/` and `docs/`. This avoids hardcoding namespace folder names (`Compute/`, `Data/`, `Security/`) so new top-level namespace folders are automatically covered without workflow changes.

**What it does:**
1. Sends a `resource-types-contrib-updated` dispatch event to `radius-project/radius` using `peter-evans/repository-dispatch@v3`
2. Includes the commit SHA in the payload for traceability (informational only -- the Radius workflow always fetches `@latest`)
3. Writes a summary to the GitHub Actions UI

**What happens if a non-manifest YAML changes?** The Radius workflow runs `make update-resource-types`, finds no diff, and exits cleanly without opening a PR. A no-op CI run (~1 minute) is the only cost.

**What happens if a new namespace folder is added here but not in `defaults.yaml`?** Only types listed in the Radius repo's `deploy/manifest/defaults.yaml` are included in the extension. The dispatch fires but `make update-resource-types` finds no changes for the unlisted namespace and no PR is opened. The new types only appear in the extension when someone adds them to `defaults.yaml` in the Radius repo.

## Dependencies

- Radius repo: [Add workflow to sync contrib resource types and publish Bicep extensions](https://github.com/radius-project/radius/pull/11916) -- the receiver of the dispatch
- Required secret: `GH_RAD_CI_BOT_PAT` with `repo` scope on `radius-project/radius`

## Changes

- `.github/workflows/notify-radius.yaml`: New workflow

## Part of

Unified Bicep extension publishing (PR 4/4). See [design doc](https://github.com/radius-project/radius/pull/11892).