### PR TITLE
feat: add optional initSql property to PostgreSQL recipe

### DIFF
--- a/Data/postgreSqlDatabases/README.md
+++ b/Data/postgreSqlDatabases/README.md
@@ -21,6 +21,7 @@ Properties for the **Radius.Data/postgreSqlDatabases** resource type are provide
 - `context.resource.properties.secretName`(string, required): name of the secret containing the database credentials
 - `context.resource.properties.size`(string, optional): The size of the database. Defaults to `S` if not provided.
 - `context.resource.properties.database`(string, optional): The name of the database. Defaults to `postgres_db` if not provided.
+- `context.resource.properties.initSql`(string, optional): SQL script to run on first database initialization. Mounted at `/docker-entrypoint-initdb.d/01-init.sql` and executed automatically by PostgreSQL on first startup.
 
 ## Recipe Output Properties
 

--- a/Data/postgreSqlDatabases/README.md
+++ b/Data/postgreSqlDatabases/README.md
@@ -21,7 +21,7 @@ Properties for the **Radius.Data/postgreSqlDatabases** resource type are provide
 - `context.resource.properties.secretName`(string, required): name of the secret containing the database credentials
 - `context.resource.properties.size`(string, optional): The size of the database. Defaults to `S` if not provided.
 - `context.resource.properties.database`(string, optional): The name of the database. Defaults to `postgres_db` if not provided.
-- `context.resource.properties.initSql`(string, optional): SQL script to run on first database initialization. Mounted at `/docker-entrypoint-initdb.d/01-init.sql` and executed automatically by PostgreSQL on first startup.
+- `context.resource.properties.initSql`(string, optional): SQL script mounted at `/docker-entrypoint-initdb.d/01-init.sql` and executed by PostgreSQL whenever PGDATA is empty. With the default ephemeral storage this runs on every pod restart; with a PersistentVolumeClaim, it runs only on the very first startup and subsequent changes are ignored on existing volumes. Limited to ~1 MiB.
 
 ## Recipe Output Properties
 

--- a/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
+++ b/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
@@ -87,6 +87,9 @@ types:
             database:
               type: string
               description: "(Optional) The name of the database. Defaults to `postgres_db` if not provided."
+            initSql:
+              type: string
+              description: "(Optional) SQL script to run on first database initialization. The script is mounted into the PostgreSQL container's `/docker-entrypoint-initdb.d/` directory and executed automatically on first startup. Useful for creating tables, indexes, and inserting seed data."
             host:
               type: string
               description: The host name used to connect to the database.

--- a/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
+++ b/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
@@ -89,7 +89,7 @@ types:
               description: "(Optional) The name of the database. Defaults to `postgres_db` if not provided."
             initSql:
               type: string
-              description: "(Optional) SQL script to run on first database initialization. The script is mounted into the PostgreSQL container's `/docker-entrypoint-initdb.d/` directory and executed automatically on first startup. Useful for creating tables, indexes, and inserting seed data."
+              description: "(Optional) SQL script mounted into the PostgreSQL container's `/docker-entrypoint-initdb.d/` directory and executed whenever PGDATA is empty. With the default ephemeral storage this runs on every pod restart. If a PersistentVolumeClaim is used, the script runs only on the very first startup and subsequent changes to initSql are ignored on existing volumes. Limited to ~1 MiB. Useful for creating tables, indexes, and inserting seed data."
             host:
               type: string
               description: The host name used to connect to the database.

--- a/Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
+++ b/Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
@@ -23,6 +23,8 @@ var namespace = context.runtime.kubernetes.namespace
 var dbSecretName = context.resource.properties.secretName
 var database = context.resource.properties.?database ?? 'postgres_db'
 var sizeValue = context.resource.properties.?size ?? 'S'
+var initSql = context.resource.properties.?initSql ?? ''
+var hasInitSql = initSql != ''
 var tag string = '16-alpine'
 var port = 5432
 var memory ={
@@ -44,6 +46,21 @@ var labels = {
   'radapp.io/resource-type':  replace(context.resource.type, '/', '-')  
   'radapp.io/resource-group': resourceGroupName  
 }  
+
+//////////////////////////////////////////
+// Init SQL ConfigMap (optional)
+//////////////////////////////////////////
+
+resource initSqlConfigMap 'core/ConfigMap@v1' = if (hasInitSql) {
+  metadata: {
+    name: '${resourceName}-init-sql'
+    namespace: namespace
+    labels: labels
+  }
+  data: {
+    '01-init.sql': initSql
+  }
+}
 
 //////////////////////////////////////////
 // PostgreSQL Deployment
@@ -106,8 +123,23 @@ resource postgresql 'apps/Deployment@v1' = {
                 value: database
               }
             ]
+            volumeMounts: hasInitSql ? [
+              {
+                name: 'init-sql'
+                mountPath: '/docker-entrypoint-initdb.d'
+                readOnly: true
+              }
+            ] : []
           }
         ]
+        volumes: hasInitSql ? [
+          {
+            name: 'init-sql'
+            configMap: {
+              name: initSqlConfigMap!.metadata.name
+            }
+          }
+        ] : []
       }
     }
   }
@@ -137,10 +169,15 @@ resource svc 'core/Service@v1' = {
 //////////////////////////////////////////
 
 output result object = {
-  resources: [
-    '/planes/kubernetes/local/namespaces/${svc.metadata.namespace}/providers/core/Service/${svc.metadata.name}'
-    '/planes/kubernetes/local/namespaces/${postgresql.metadata.namespace}/providers/apps/Deployment/${postgresql.metadata.name}'
-  ]
+  resources: union(
+    [
+      '/planes/kubernetes/local/namespaces/${svc.metadata.namespace}/providers/core/Service/${svc.metadata.name}'
+      '/planes/kubernetes/local/namespaces/${postgresql.metadata.namespace}/providers/apps/Deployment/${postgresql.metadata.name}'
+    ],
+    hasInitSql ? [
+      '/planes/kubernetes/local/namespaces/${initSqlConfigMap!.metadata.namespace}/providers/core/ConfigMap/${initSqlConfigMap!.metadata.name}'
+    ] : []
+  )
   values: {
     host: '${svc.metadata.name}.${svc.metadata.namespace}.svc.cluster.local'
     port: port

--- a/Data/postgreSqlDatabases/test/app.bicep
+++ b/Data/postgreSqlDatabases/test/app.bicep
@@ -47,6 +47,12 @@ resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
     application: myapp.id
     size: 'S'
     secretName: dbSecret.name
+    initSql: '''
+      CREATE TABLE IF NOT EXISTS demo (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(255)
+      );
+    '''
   }
 }
 


### PR DESCRIPTION
Closes #165

## Summary

Add support for an optional `initSql` property on the `Radius.Data/postgreSqlDatabases` resource type, enabling users to provide a SQL initialization script that runs automatically on first database startup.

## Problem

The PostgreSQL recipe currently deploys a vanilla `postgres:16-alpine` container with no mechanism to initialize the database schema. Applications that depend on pre-existing tables, indexes, or seed data (e.g., [FINOS TraderX](https://github.com/finos/traderX)) fail at runtime because the database starts empty.

In Docker Compose workflows, this is typically handled by copying a `.sql` file into `/docker-entrypoint-initdb.d/`, which PostgreSQL's entrypoint script executes on first boot. The Radius recipe had no equivalent mechanism.

## Solution

When the `initSql` property is provided:

1. A **ConfigMap** is created containing the SQL script as `01-init.sql`
2. The ConfigMap is **volume-mounted** into the PostgreSQL container at `/docker-entrypoint-initdb.d/`
3. PostgreSQL automatically executes the script on first initialization

The property is **optional and fully backward-compatible** — existing deployments without `initSql` continue to work unchanged (no ConfigMap is created, no volumes are mounted).

### Example usage

```bicep
resource database 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
  name: 'database'
  properties: {
    environment: environment
    application: application.id
    size: 'S'
    secretName: dbCredentials.name
    initSql: '''
      CREATE TABLE users (
        id SERIAL PRIMARY KEY,
        name VARCHAR(255)
      );
    '''
  }
}
```

## Changes

- **`postgreSqlDatabases.yaml`**: Added optional `initSql` string property to the schema
- **`kubernetes-postgresql.bicep`**: Conditionally creates a ConfigMap and mounts it as a volume when `initSql` is provided; includes ConfigMap in recipe output resources
- **`README.md`**: Documented the new property
- **`test/app.bicep`**: Updated example to demonstrate `initSql` usage