### PR TITLE
Use radius extension instead of per-namespace extensions

### DIFF
--- a/Compute/containers/test/app.bicep
+++ b/Compute/containers/test/app.bicep
@@ -1,7 +1,4 @@
 extension radius
-extension containers
-extension persistentVolumes
-extension secrets
 
 param environment string
 

--- a/Data/mySqlDatabases/test/app.bicep
+++ b/Data/mySqlDatabases/test/app.bicep
@@ -1,7 +1,4 @@
 extension radius
-extension containers
-extension mySqlDatabases
-extension secrets
 
 @description('The Radius environment ID')
 param environment string

--- a/Data/neo4jDatabases/test/app.bicep
+++ b/Data/neo4jDatabases/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
-extension containers
 extension neo4jDatabases
-extension secrets
 
 @description('The Radius environment ID')
 param environment string

--- a/Data/postgreSqlDatabases/test/app.bicep
+++ b/Data/postgreSqlDatabases/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
-extension containers
 extension postgreSqlDatabases
-extension secrets
 
 @description('The Radius environment ID')
 param environment string

--- a/Security/secrets/test/app.bicep
+++ b/Security/secrets/test/app.bicep
@@ -1,5 +1,4 @@
 extension radius
-extension secrets
 
 @description('The Radius environment ID')
 param environment string


### PR DESCRIPTION
All contrib resource types that are registered as defaults are now included in the unified `radius` Bicep extension (`br:biceptypes.azurecr.io/radius`). This PR removes per-namespace extension imports from test `.bicep` files for default resource types to fix BCP264 duplicate namespace errors (e.g. `Radius.Security/secrets` declared in both `radius` and `secrets`). For non-default types (neo4j, postgres), removes `containers` and `secrets` extensions since those are now in `radius`.

### Files changed

| File | Change |
|------|--------|
| `Security/secrets/test/app.bicep` | Removed `extension secrets` |
| `Compute/containers/test/app.bicep` | Removed `extension containers`, `persistentVolumes`, `secrets` |
| `Data/mySqlDatabases/test/app.bicep` | Removed `extension containers`, `mySqlDatabases`, `secrets` |
| `Data/neo4jDatabases/test/app.bicep` | Removed `extension containers`, `secrets` |
| `Data/postgreSqlDatabases/test/app.bicep` | Removed `extension containers`, `secrets` |

Fixes the CI failure in https://github.com/radius-project/resource-types-contrib/actions/runs/26047347681/job/76574908556