### PR TITLE
fix: skip Azure validation checks for PRs with no Azure file changes

### DIFF
--- a/.github/scripts/test-recipe.sh
+++ b/.github/scripts/test-recipe.sh
@@ -178,7 +178,7 @@ if grep -q 'param password' "$TEST_FILE" 2>/dev/null; then
 fi
 
 # Deploy the test app
-if rad deploy "$TEST_FILE" --application "$APP_NAME" -e "$ENVIRONMENT_NAME" $PARAMS; then
+if rad deploy "$TEST_FILE" --application "$APP_NAME" -e "$ENVIRONMENT_PATH" $PARAMS; then
     echo "==> Test deployment successful"
     
     # Cleanup: delete the app
@@ -196,7 +196,7 @@ else
     rad app delete "$APP_NAME" --yes 2>/dev/null || true
     rad recipe unregister default \
         --workspace "$WORKSPACE_NAME" \
-        --environment "$ENVIRONMENT_NAME" \
+        --environment "$ENVIRONMENT_PATH" \
         --resource-type "$RESOURCE_TYPE"
 
     # Clean up leftover K8s resources even on failure

--- a/.github/workflows/validate-azure-recipes.yaml
+++ b/.github/workflows/validate-azure-recipes.yaml
@@ -42,28 +42,34 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      azure-changed: ${{ steps.filter.outputs.azure-changed }}
+      azure-changed: ${{ steps.result.outputs.azure-changed }}
     steps:
+      # REST API mode: no checkout needed, works with fork PRs. Only supports
+      # pull_request* events — non-PR events skip this and default to azure-changed=true.
       - name: Detect Azure file changes
         id: filter
+        if: github.event_name == 'pull_request_target'
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          use_rest_api: true
+          files: |
+            **/azure/**
+            **/azure-*/**
+            **/test/app.bicep
+            .github/workflows/validate-azure-recipes.yaml
+
+      - name: Set result
+        id: result
         env:
-          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          ANY_MODIFIED: ${{ steps.filter.outputs.any_modified }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
-            echo "Non-PR event — assuming Azure files changed"
-            echo "azure-changed=true" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          FILES="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')"
-          if echo "${FILES}" | grep -qE '(^|/)azure/|(^|/)azure-[^/]+/|(^|/)test/app\.bicep$|^\.github/workflows/validate-azure-recipes\.yaml$'; then
-            echo "Azure files detected in PR:"
-            echo "${FILES}" | grep -E '(^|/)azure/|(^|/)azure-[^/]+/|(^|/)test/app\.bicep$|^\.github/workflows/validate-azure-recipes\.yaml$' || true
-            echo "azure-changed=true" >> "${GITHUB_OUTPUT}"
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            echo "azure-changed=$ANY_MODIFIED" >> "$GITHUB_OUTPUT"
           else
-            echo "No Azure files changed — skipping Azure validation"
-            echo "azure-changed=false" >> "${GITHUB_OUTPUT}"
+            echo "Non-PR event — assuming Azure files changed"
+            echo "azure-changed=true" >> "$GITHUB_OUTPUT"
           fi
 
   # When no Azure files changed, report the required check names as successful

--- a/.github/workflows/validate-azure-recipes.yaml
+++ b/.github/workflows/validate-azure-recipes.yaml
@@ -13,13 +13,13 @@ on:
   # pull_request_target runs in the context of the base branch, providing access to secrets.
   # For external contributors, the approval-gate job requires manual approval before tests run.
   # SECURITY: We use pull_request_target but do NOT run any code from the PR until after approval.
+  #
+  # NOTE: No paths filter on pull_request_target. The "check-paths" job below determines
+  # whether Azure files changed. When they haven't, the "skip-azure-validation" job
+  # reports the required check names so branch protection is satisfied without running
+  # expensive Azure tests.
   pull_request_target:
     branches: [main]
-    paths:
-      - "**/azure/**"
-      - "**/azure-*/**"
-      - "**/test/app.bicep"
-      - ".github/workflows/validate-azure-recipes.yaml"
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -33,6 +33,55 @@ on:
 permissions: {}
 
 jobs:
+  # Detect whether Azure-related files changed. For non-PR events (push, merge_group,
+  # workflow_dispatch) the output defaults to 'true' so tests always run.
+  check-paths:
+    name: Check Paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      azure-changed: ${{ steps.filter.outputs.azure-changed }}
+    steps:
+      - name: Detect Azure file changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "pull_request_target" ]; then
+            echo "Non-PR event — assuming Azure files changed"
+            echo "azure-changed=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          FILES="$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate --jq '.[].filename')"
+          if echo "${FILES}" | grep -qE '(^|/)azure/|(^|/)azure-[^/]+/|(^|/)test/app\.bicep$|^\.github/workflows/validate-azure-recipes\.yaml$'; then
+            echo "Azure files detected in PR:"
+            echo "${FILES}" | grep -E '(^|/)azure/|(^|/)azure-[^/]+/|(^|/)test/app\.bicep$|^\.github/workflows/validate-azure-recipes\.yaml$' || true
+            echo "azure-changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "No Azure files changed — skipping Azure validation"
+            echo "azure-changed=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+  # When no Azure files changed, report the required check names as successful
+  # so that branch protection is satisfied.
+  skip-azure-validation:
+    needs: [check-paths]
+    if: needs.check-paths.outputs.azure-changed != 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    name: Validate Azure ${{ matrix.recipe }} Recipes
+    strategy:
+      matrix:
+        recipe: [bicep, terraform]
+    permissions: {}
+    steps:
+      - name: Skip
+        run: echo "No Azure files changed — skipping Azure ${{ matrix.recipe }} recipe validation"
+
   # Trust check for pull_request_target events. Determines whether the PR author
   # is a trusted contributor (same-repo push) or an external contributor.
   #
@@ -42,9 +91,10 @@ jobs:
   #   2. Fork PR: external (requires approval).
   check-trust:
     name: Check Trust
+    needs: [check-paths]
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    if: github.event_name == 'pull_request_target'
+    if: github.event_name == 'pull_request_target' && needs.check-paths.outputs.azure-changed == 'true'
     outputs:
       is-external: ${{ steps.check.outputs.is-external }}
     permissions: {}
@@ -83,12 +133,13 @@ jobs:
         run: echo "Tests approved to run for commit ${{ github.event.pull_request.head.sha }}"
 
   validate-azure-recipes:
-    needs: [check-trust, approval-gate]
+    needs: [check-paths, check-trust, approval-gate]
     # For pull_request_target, require approval-gate to be 'success' or 'skipped' — block
     # on 'cancelled' (rejected approval) to prevent running PR code with secrets.
     # For push, workflow_dispatch, and merge_group, both gate jobs are skipped.
     if: |
       !cancelled() &&
+      needs.check-paths.outputs.azure-changed == 'true' &&
       (needs.check-trust.result == 'success' || needs.check-trust.result == 'skipped') &&
       (needs.approval-gate.result == 'success' || needs.approval-gate.result == 'skipped')
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The branch ruleset requires Validate Azure bicep Recipes and Validate Azure terraform Recipes checks to pass for every PR. However, the workflow used paths: filters onpull_request_target, so these checks never reported when no Azure files changed — blocking merge for unrelated PRs.
This pull request introduces a new job to detect Azure-related file changes and conditionally skips validation, ensuring required checks still pass for branch protection. The main changes are:

**Conditional Azure validation:**

* Removed the `paths` filter from the `pull_request_target` trigger and added a new `check-paths` job to programmatically detect if Azure-related files were changed in a PR. 
* Added a `skip-azure-validation` job that marks Azure validation checks as passed when no Azure files changed, satisfying branch protection without running tests.


## Testing
PR with no azure files updated passes tests Validate Azure bicep Recipes and Validate Azure terraform Recipes

## Contributor Checklist

- [ ] File names follow naming conventions and folder structure
- [ ] Platform engineer documentation is in README.md
- [ ] Developer documentation is the top-level description property
- [ ] Example of defining the Resource Type is in the developer documentation
- [ ] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [ ] All properties in the Resource Type definition have clear descriptions
- [ ] Enum properties have values defined in `enum: []`
- [ ] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [ ] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [ ] Recipes include a results output variable with all read-only properties set
- [ ] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [ ] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [ ] Recipes are provided for at least one platform
- [ ] Recipes handle secrets securely
- [ ] Recipes are idempotent
- [ ] Resource types and recipes were tested
