### PR TITLE
Add Gateway API and NGINX recipes

### DIFF
--- a/Compute/gateways/README.md
+++ b/Compute/gateways/README.md
@@ -1,0 +1,38 @@
+# Radius.Compute/gateways
+
+`Radius.Compute/gateways` creates a Kubernetes Gateway API `Gateway` for application ingress. The Kubernetes nginx recipes target NGINX Gateway Fabric by creating or reusing the `nginx` `GatewayClass`.
+
+## Kubernetes nginx recipe
+
+The nginx recipe expects NGINX Gateway Fabric to be installed in the cluster. The default NGINX Gateway Fabric Helm installation creates the `nginx` GatewayClass, and this recipe creates a Gateway that references it.
+
+The recipe outputs:
+
+- `gatewayName`: Kubernetes Gateway name.
+- `gatewayNamespace`: Kubernetes namespace containing the Gateway.
+- `resources`: Radius resource IDs for the Gateway.
+
+## Example
+
+```bicep
+extension radius
+extension gateways
+
+param environment string
+
+resource gateway 'Radius.Compute/gateways@2025-08-01-preview' = {
+  name: 'web'
+  properties: {
+    environment: environment
+    gatewayClassName: 'nginx'
+    listeners: [
+      {
+        name: 'http'
+        protocol: 'HTTP'
+        port: 80
+        allowedRoutesFrom: 'All'
+      }
+    ]
+  }
+}
+```

--- a/Compute/gateways/gateways.yaml
+++ b/Compute/gateways/gateways.yaml
@@ -1,0 +1,76 @@
+namespace: Radius.Compute
+types:
+  gateways:
+    description: |
+      The Radius.Compute/gateways Resource Type defines an ingress Gateway for application traffic.
+      On Kubernetes, the nginx recipe creates a Gateway API Gateway that is reconciled by NGINX Gateway Fabric.
+
+      ```
+      extension radius
+      extension gateways
+
+      param environment string
+
+      resource gateway 'Radius.Compute/gateways@2025-08-01-preview' = {
+        name: 'web'
+        properties: {
+          environment: environment
+          gatewayClassName: 'nginx'
+          listeners: [
+            {
+              name: 'http'
+              protocol: 'HTTP'
+              port: 80
+              allowedRoutesFrom: 'All'
+            }
+          ]
+        }
+      }
+      ```
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: (Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`.
+            application:
+              type: string
+              description: (Optional) The Radius Application ID. `myApplication.id` for example.
+            gatewayClassName:
+              type: string
+              description: (Optional) The Kubernetes GatewayClass name. The value is assumed to be `nginx`.
+            listeners:
+              type: array
+              description: (Optional) The Gateway listeners to expose. The value is assumed to be one HTTP listener on port `80`.
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: (Required) The listener name.
+                  protocol:
+                    type: string
+                    enum: [HTTP, HTTPS, TLS, TCP, UDP]
+                    description: (Required) The listener protocol.
+                  port:
+                    type: integer
+                    description: (Required) The listener port.
+                  hostname:
+                    type: string
+                    description: (Optional) The hostname accepted by the listener.
+                  allowedRoutesFrom:
+                    type: string
+                    enum: [All, Same, Selector]
+                    description: (Optional) The namespaces allowed to attach routes. The value is assumed to be `Same`.
+                required: [name, protocol, port]
+            gatewayName:
+              type: string
+              readOnly: true
+              description: (Read Only) The Kubernetes Gateway name created by the recipe.
+            gatewayNamespace:
+              type: string
+              readOnly: true
+              description: (Read Only) The Kubernetes namespace containing the Gateway.
+          required: [environment]

--- a/Compute/gateways/recipes/kubernetes/bicep/nginx-gateway.bicep
+++ b/Compute/gateways/recipes/kubernetes/bicep/nginx-gateway.bicep
@@ -1,0 +1,68 @@
+@description('Radius-provided deployment context.')
+param context object
+
+extension kubernetes with {
+  namespace: context.runtime.kubernetes.namespace
+  kubeConfig: ''
+} as kubernetes
+
+var resourceName = context.resource.name
+var properties = context.resource.properties
+var gatewayClassName = properties.?gatewayClassName ?? 'nginx'
+var listeners = properties.?listeners ?? [
+  {
+    name: 'http'
+    protocol: 'HTTP'
+    port: 80
+    allowedRoutesFrom: 'Same'
+  }
+]
+var environmentSegments = properties.environment != null ? split(string(properties.environment), '/') : []
+var environmentLabel = length(environmentSegments) > 0 ? last(environmentSegments) : ''
+var resourceSegments = split(string(context.resource.id), '/')
+var resourceGroup = length(resourceSegments) > 4 ? resourceSegments[4] : ''
+var resourceType = context.resource.?type ?? (length(resourceSegments) > 6 ? '${resourceSegments[5]}/${resourceSegments[6]}' : '')
+var resourceTypeLabel = replace(resourceType, '/', '.')
+var labels = {
+  'radapp.io/resource': resourceName
+  'radapp.io/environment': environmentLabel
+  'radapp.io/application': context.application == null ? '' : context.application.name
+  'radapp.io/resource-type': resourceTypeLabel
+  'radapp.io/resource-group': resourceGroup
+}
+
+resource gateway 'gateway.networking.k8s.io/gateways@v1' = {
+  metadata: {
+    name: resourceName
+    namespace: context.runtime.kubernetes.namespace
+    labels: labels
+  }
+  spec: {
+    gatewayClassName: gatewayClassName
+    listeners: [
+      for listener in listeners: union(
+        {
+          name: listener.name
+          protocol: listener.protocol
+          port: listener.port
+          allowedRoutes: {
+            namespaces: {
+              from: listener.?allowedRoutesFrom ?? 'Same'
+            }
+          }
+        },
+        (listener.?hostname ?? '') != '' ? { hostname: listener.hostname } : {}
+      )
+    ]
+  }
+}
+
+output result object = {
+  resources: [
+    '/planes/kubernetes/local/namespaces/${context.runtime.kubernetes.namespace}/providers/gateway.networking.k8s.io/Gateway/${gateway.name}'
+  ]
+  values: {
+    gatewayName: gateway.name
+    gatewayNamespace: context.runtime.kubernetes.namespace
+  }
+}

--- a/Compute/gateways/recipes/kubernetes/terraform/main.tf
+++ b/Compute/gateways/recipes/kubernetes/terraform/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.37.1"
+    }
+  }
+}
+
+locals {
+  properties           = var.context.resource.properties
+  resource_name        = var.context.resource.name
+  namespace            = var.context.runtime.kubernetes.namespace
+  gateway_class_name   = try(local.properties.gatewayClassName, "nginx")
+  listeners            = try(local.properties.listeners, [{ name = "http", protocol = "HTTP", port = 80, allowedRoutesFrom = "Same" }])
+  resource_id          = var.context.resource.id
+  resource_segments    = split("/", local.resource_id)
+  resource_group       = length(local.resource_segments) > 4 ? local.resource_segments[4] : ""
+  resource_type        = try(var.context.resource.type, length(local.resource_segments) > 6 ? "${local.resource_segments[5]}/${local.resource_segments[6]}" : "")
+  resource_type_label  = replace(local.resource_type, "/", ".")
+  environment_value    = try(tostring(local.properties.environment), "")
+  environment_segments = local.environment_value != "" ? split("/", local.environment_value) : []
+  environment_label    = length(local.environment_segments) > 0 ? local.environment_segments[length(local.environment_segments) - 1] : ""
+  labels = {
+    "radapp.io/resource"       = local.resource_name
+    "radapp.io/environment"    = local.environment_label
+    "radapp.io/application"    = var.context.application == null ? "" : var.context.application.name
+    "radapp.io/resource-type"  = local.resource_type_label
+    "radapp.io/resource-group" = local.resource_group
+  }
+}
+
+resource "kubernetes_manifest" "gateway" {
+  manifest = {
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name      = local.resource_name
+      namespace = local.namespace
+      labels    = local.labels
+    }
+    spec = {
+      gatewayClassName = local.gateway_class_name
+      listeners = [
+        for listener in local.listeners : merge(
+          {
+            name     = listener.name
+            protocol = listener.protocol
+            port     = listener.port
+            allowedRoutes = {
+              namespaces = {
+                from = try(listener.allowedRoutesFrom, "Same")
+              }
+            }
+          },
+          try(listener.hostname, "") != "" ? { hostname = listener.hostname } : {}
+        )
+      ]
+    }
+  }
+}
+
+output "result" {
+  description = "Resource IDs and values created by the gateway recipe."
+  value = {
+    resources = [
+      "/planes/kubernetes/local/namespaces/${local.namespace}/providers/gateway.networking.k8s.io/Gateway/${local.resource_name}"
+    ]
+    values = {
+      gatewayName      = local.resource_name
+      gatewayNamespace = local.namespace
+    }
+  }
+}

--- a/Compute/gateways/recipes/kubernetes/terraform/var.tf
+++ b/Compute/gateways/recipes/kubernetes/terraform/var.tf
@@ -1,0 +1,5 @@
+variable "context" {
+  description = "This variable contains Radius recipe context."
+  type        = any
+  default     = null
+}

--- a/Compute/gateways/test/app.bicep
+++ b/Compute/gateways/test/app.bicep
@@ -1,0 +1,28 @@
+extension radius
+extension gateways
+
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'gateways-testapp'
+  properties: {
+    environment: environment
+  }
+}
+
+resource gateway 'Radius.Compute/gateways@2025-08-01-preview' = {
+  name: 'web'
+  properties: {
+    environment: environment
+    application: app.id
+    gatewayClassName: 'nginx'
+    listeners: [
+      {
+        name: 'http'
+        protocol: 'HTTP'
+        port: 80
+        allowedRoutesFrom: 'All'
+      }
+    ]
+  }
+}

--- a/Compute/routes/recipes/kubernetes/bicep/kubernetes-routes.bicep
+++ b/Compute/routes/recipes/kubernetes/bicep/kubernetes-routes.bicep
@@ -35,7 +35,7 @@ var labels = {
 
 
 // Create HTTPRoute for HTTP routing using Gateway API
-resource httpRoute 'gateway.networking.k8s.io/HTTPRoute@v1' = if (routeKind == 'HTTP') {
+resource httpRoute 'gateway.networking.k8s.io/httproutes@v1' = if (routeKind == 'HTTP') {
   metadata: {
     name: 'routes-${uniqueString(context.resource.id)}'
     namespace: context.runtime.kubernetes.namespace
@@ -56,7 +56,7 @@ resource httpRoute 'gateway.networking.k8s.io/HTTPRoute@v1' = if (routeKind == '
 }
 
 // Create TLSRoute for TLS routing using Gateway API
-resource tlsRoute 'gateway.networking.k8s.io/TLSRoute@v1alpha2' = if (routeKind == 'TLS') {
+resource tlsRoute 'gateway.networking.k8s.io/tlsroutes@v1alpha2' = if (routeKind == 'TLS') {
   metadata: {
     name: 'routes-${uniqueString(context.resource.id)}'
     namespace: context.runtime.kubernetes.namespace
@@ -77,7 +77,7 @@ resource tlsRoute 'gateway.networking.k8s.io/TLSRoute@v1alpha2' = if (routeKind 
 }
 
 // Create TCPRoute for TCP routing using Gateway API
-resource tcpRoute 'gateway.networking.k8s.io/TCPRoute@v1alpha2' = if (routeKind == 'TCP') {
+resource tcpRoute 'gateway.networking.k8s.io/tcproutes@v1alpha2' = if (routeKind == 'TCP') {
   metadata: {
     name: 'routes-${uniqueString(context.resource.id)}'
     namespace: context.runtime.kubernetes.namespace
@@ -108,7 +108,7 @@ resource tcpRoute 'gateway.networking.k8s.io/TCPRoute@v1alpha2' = if (routeKind 
 }
 
 // Create UDPRoute for UDP routing using Gateway API
-resource udpRoute 'gateway.networking.k8s.io/UDPRoute@v1alpha2' = if (routeKind == 'UDP') {
+resource udpRoute 'gateway.networking.k8s.io/udproutes@v1alpha2' = if (routeKind == 'UDP') {
   metadata: {
     name: 'routes-${uniqueString(context.resource.id)}'
     namespace: context.runtime.kubernetes.namespace

--- a/Compute/routes/test/app.bicep
+++ b/Compute/routes/test/app.bicep
@@ -1,0 +1,54 @@
+extension radius
+extension containers
+extension routes
+
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'routes-testapp'
+  properties: {
+    environment: environment
+  }
+}
+
+resource web 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'web'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      web: {
+        image: 'nginx:alpine'
+        ports: {
+          http: {
+            containerPort: 80
+            protocol: 'TCP'
+          }
+        }
+      }
+    }
+  }
+}
+
+resource route 'Radius.Compute/routes@2025-08-01-preview' = {
+  name: 'web'
+  properties: {
+    environment: environment
+    application: app.id
+    kind: 'HTTP'
+    rules: [
+      {
+        matches: [
+          {
+            httpPath: '/'
+          }
+        ]
+        destinationContainer: {
+          resourceId: web.id
+          containerName: 'web'
+          containerPort: web.properties.containers.web.ports.http.containerPort
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds the Gateway API / NGINX Gateway Fabric recipe files that were split out of the focused Contour HTTPProxy PR.

This PR adds:

- `Radius.Compute/gateways` resource type metadata and docs.
- A Kubernetes Gateway API gateway recipe for NGINX Gateway Fabric in Bicep.
- A Kubernetes Gateway API gateway recipe for NGINX Gateway Fabric in Terraform.
- Minimal gateway and route test apps.
- A Gateway API Bicep route recipe casing fix so resources use the lower-case plural Kubernetes resource names.

## Scope

Included:

- `Compute/gateways/README.md`
- `Compute/gateways/gateways.yaml`
- `Compute/gateways/recipes/kubernetes/bicep/nginx-gateway.bicep`
- `Compute/gateways/recipes/kubernetes/terraform/*`
- `Compute/gateways/test/app.bicep`
- `Compute/routes/test/app.bicep`
- `Compute/routes/recipes/kubernetes/bicep/kubernetes-routes.bicep`

Not included:

- Contour HTTPProxy recipes. Those are in https://github.com/radius-project/resource-types-contrib/pull/172.
- Demo CI script changes.
- Container connection handling fixes.

## Relationship to Contour PR

This PR overlaps with #172 on `Compute/gateways/README.md` and `Compute/gateways/gateways.yaml` because both recipe families need the `Radius.Compute/gateways` resource type. Whichever PR merges second should be rebased and reconcile the gateway docs to mention both Contour HTTPProxy and Gateway API recipe variants.

## Validation

Ran:

```bash
terraform fmt -check -recursive Compute/gateways/recipes/kubernetes/terraform
bash -n .github/scripts/build-resource-type.sh .github/scripts/build-terraform-recipe.sh .github/scripts/build-bicep-recipe.sh
git diff --cached --check
```

The broader Gateway API / NGINX path was previously validated end to end in the demo repo:

- https://github.com/willdavsmith/radius-nginx-demo/actions/runs/26118318007
