### PR TITLE
Align Bicep container Service names with routes

### DIFF
--- a/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+++ b/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
@@ -321,7 +321,7 @@ var servicesConfig = reduce(containerItems, [], (acc, item) =>
 
 resource services 'core/Service@v1' = [for svc in servicesConfig: {
   metadata: {
-    name: svc.containerName
+    name: '${normalizedName}-${svc.containerName}'
     namespace: namespace
     labels: union(labels, {
       container: svc.containerName
@@ -394,7 +394,7 @@ resource hpa 'autoscaling/HorizontalPodAutoscaler@v2' = if (hasAutoScaling) {
 }
 
 var deploymentResource = '/planes/kubernetes/local/namespaces/${namespace}/providers/apps/Deployment/${normalizedName}'
-var serviceResources = reduce(servicesConfig, [], (acc, svc) => concat(acc, ['/planes/kubernetes/local/namespaces/${namespace}/providers/core/Service/${svc.containerName}']))
+var serviceResources = reduce(servicesConfig, [], (acc, svc) => concat(acc, ['/planes/kubernetes/local/namespaces/${namespace}/providers/core/Service/${normalizedName}-${svc.containerName}']))
 var hpaResource = hasAutoScaling ? ['/planes/kubernetes/local/namespaces/${namespace}/providers/autoscaling/HorizontalPodAutoscaler/${normalizedName}'] : []
 
 var allResources = concat([deploymentResource], serviceResources, hpaResource)


### PR DESCRIPTION
## Summary

Fixes #180 by aligning the Kubernetes Bicep `Radius.Compute/containers` recipe with the existing route backend naming convention.

The Bicep containers recipe now creates per-container Kubernetes Services as:

```text
<container-resource-name>-<container-name>
```

This matches the existing Bicep routes recipe and the existing Terraform containers/routes recipes.

## Why

`Radius.Compute/routes` requires `destinationContainer.resourceId`, `destinationContainer.containerName`, and `destinationContainer.containerPort`. Since Kubernetes Service names are namespace-scoped, using both the container resource name and container name avoids collisions across multiple container resources that contain containers with the same name.

Before this change, the Bicep containers recipe created Services named only `<container-name>`, while the Bicep routes recipe referenced `<container-resource-name>-<container-name>`, so routes could point at Services that did not exist.

## Changes

- Update the Bicep Kubernetes containers recipe Service name to `<container-resource-name>-<container-name>`.
- Update the Bicep containers recipe output resource IDs to report the new Service names.
- Leave the existing route recipes unchanged.

## Validation

- `git diff --check origin/main -- Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep Compute/routes/recipes/kubernetes/bicep/kubernetes-routes.bicep Compute/routes/recipes/kubernetes/terraform/main.tf`
- Attempted `make build-bicep-recipe RECIPE_PATH=Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep`, but the local `localhost:5000` recipe registry required by the build script was not running.
