### PR TITLE
containerImages: workaround Security/secrets double-encoding (#176)

### DIFF
--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -125,10 +125,17 @@ data "kubernetes_secret" "registry_creds" {
 }
 
 locals {
-  # kubernetes_secret data source returns already-decoded values
-  # (the provider decodes the base64 from the K8s API).
-  registry_username = local.use_auth ? data.kubernetes_secret.registry_creds[0].data["username"] : ""
-  registry_password = local.use_auth ? data.kubernetes_secret.registry_creds[0].data["password"] : ""
+  # Workaround for Security/secrets recipe double-encoding bug
+  # (resource-types-contrib#176): the secrets/kubernetes/terraform
+  # recipe calls base64encode(plaintext) before assigning to the
+  # TF kubernetes_secret resource's `data` field, but the TF
+  # provider routes that field to StringData (plaintext-in) and
+  # K8s base64-encodes again on admission. The result on disk is
+  # base64(base64(plaintext)). Consumers (us) get the still-encoded
+  # value from the data source and have to decode once.
+  # Drop this base64decode when #176 lands.
+  registry_username = local.use_auth ? base64decode(data.kubernetes_secret.registry_creds[0].data["username"]) : ""
+  registry_password = local.use_auth ? base64decode(data.kubernetes_secret.registry_creds[0].data["password"]) : ""
 
   docker_config_json = local.use_auth ? jsonencode({
     auths = {


### PR DESCRIPTION
## Summary

Re-applies the `base64decode()` workaround on the registry credentials read in `Compute/containerImages/recipes/kubernetes/terraform/main.tf`. This was removed during PR #151 review based on a mistaken understanding of the kubernetes_secret data source's encoding behavior, breaking all real-world authenticated pushes since 2026-05-29.

## Root cause

The Security/secrets kubernetes terraform recipe writes secret values like this:

```hcl
string_data = {
  for k, v in local.secret_data : k => base64encode(v.value)
}
# ...
resource "kubernetes_secret" "this" {
  data = length(local.string_data) > 0 ? local.string_data : {}
}
```

The TF `kubernetes_secret` resource's `data` field is routed through to corev1.Secret.`StringData` (plaintext-in) by the provider. The K8s API server then base64-encodes on admission to populate `.data`. Result on disk: `base64(base64(plaintext))`. Consumers reading via the data source get the still-encoded value back and must decode once. Tracked as resource-types-contrib#176.

## Impact

The containerImages recipe builds the docker `config.json` auth header as:

```hcl
auth = base64encode("${local.registry_username}:${local.registry_password}")
```

Without the workaround, `registry_username` and `registry_password` are still base64-encoded when the auth header is constructed. The header becomes `base64(base64encoded-user:base64encoded-pass)` instead of `base64(plaintext-user:plaintext-pass)`. Registries reject this as a credential format error: GHCR returns `403 Forbidden` from its token endpoint with the cryptic message `failed to fetch oauth token: unexpected status from GET .../token?scope=...:pull,push\u0026service=ghcr.io: 403 Forbidden`.

## Verification

The demo repo at willdavsmith/radius-containerimagetype-demo has E2E workflows (kind, k3d, AKS, EKS) that exercise the full `Radius.Compute/containerImages` flow against GHCR. The last successful run is from 2026-05-29 (run [26660465098](https://github.com/willdavsmith/radius-containerimagetype-demo/actions/runs/26660465098)); every run after the recipe change that removed the workaround has failed at the push step with the 403. With this PR's recipe, builds and pushes succeed.

## Long-term fix

When #176 lands (secrets recipe correctly populates `data` for base64-encoded inputs and `stringData` for plaintext, mirroring the Bicep recipe pattern), this workaround can be removed.

Until then, every consumer of credentials from a `Radius.Security/secrets`-backed resource has to apply this same decode workaround. Adding the comment makes the situation discoverable for future recipe authors.