### PR TITLE
Rename recipe pack recipeKind/recipeLocation to kind/source

### DIFF
--- a/.github/scripts/generate-recipe-pack.sh
+++ b/.github/scripts/generate-recipe-pack.sh
@@ -104,8 +104,8 @@ for recipe_dir in "${RECIPE_DIRS[@]}"; do
     # Add recipe entry to the template
     cat >> "$OUTPUT_FILE" << EOF
       '$RESOURCE_TYPE': {
-        recipeKind: '$RECIPE_KIND'
-        recipeLocation: '$TEMPLATE_PATH'
+        kind: '$RECIPE_KIND'
+        source: '$TEMPLATE_PATH'
         plainHttp: true
       }
 EOF

--- a/Compute/containerImages/README.md
+++ b/Compute/containerImages/README.md
@@ -36,8 +36,8 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
   properties: {
     recipes: {
       'Radius.Compute/containerImages': {
-        recipeKind: 'terraform'
-        recipeLocation: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform'
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform'
         parameters: {
           registry: 'ghcr.io/my-org'
           registrySecretName: 'ghcr-creds'


### PR DESCRIPTION
## Description

Updates the recipe pack generator and the container images sample to use the renamed `Radius.Core/recipePacks@2025-08-01-preview` field names.

- `.github/scripts/generate-recipe-pack.sh`: emit `kind`/`source` instead of `recipeKind`/`recipeLocation`.
- `Compute/containerImages/README.md`: update the sample recipe pack.

Companion to radius-project/radius#12104 (implements radius-project/radius#11879). The schema rename is breaking for the preview API, so this must ship alongside that radius change — recipe packs authored with the old field names will not resolve on the updated control plane.

## Type of change

- This pull request adds or changes features of Radius and has an approved issue (issue link required).

Fixes: radius-project/radius#11879