### PR TITLE
Add Dependabot cooldown to all updates entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -17,11 +19,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       go-deps:
         patterns:


### PR DESCRIPTION
## Description

Adds a `cooldown` block (`default-days: 7`) to every active `updates:` entry in `.github/dependabot.yml`. The cooldown delays Dependabot update PRs until 7 days after a release, reducing PR churn from brand-new releases.

This change is scoped to this repository and is part of an org-wide rollout following [radius-project/radius #12141](https://github.com/radius-project/radius/pull/12141) ("Add Dependabot cooldown to all updates entries").

Affected ecosystems: `github-actions`, `devcontainers`, `gomod`. Commented-out entries (if any) were left untouched. The file remains valid YAML and schema-valid (Dependabot v2 / schemastore 2.0).

This is a **maintenance / no-functional-change** task — it only affects how Dependabot schedules dependency update PRs and introduces no changes to resource types, recipes, or application code.

Related GitHub Issue: N/A

## Testing

No functional testing required. Validated that `.github/dependabot.yml` parses as valid YAML and conforms to the Dependabot v2 schema. GitHub will validate the Dependabot config on merge.

## Contributor Checklist

N/A — this PR only updates Dependabot configuration and does not add or modify Resource Types or Recipes.