### PR TITLE
ci: always report required Resource Types checks on PRs

### DIFF
--- a/.github/workflows/validate-azure-recipes.yaml
+++ b/.github/workflows/validate-azure-recipes.yaml
@@ -10,6 +10,9 @@ on:
       - "**/azure-*/**"
       - "**/test/app.bicep"
       - ".github/workflows/validate-azure-recipes.yaml"
+      - ".github/scripts/**"
+      - ".github/build/**"
+      - "Makefile"
   # pull_request_target runs in the context of the base branch, providing access to secrets.
   # For external contributors, the approval-gate job requires manual approval before tests run.
   # SECURITY: We use pull_request_target but do NOT run any code from the PR until after approval.
@@ -57,6 +60,9 @@ jobs:
             **/azure-*/**
             **/test/app.bicep
             .github/workflows/validate-azure-recipes.yaml
+            .github/scripts/**
+            .github/build/**
+            Makefile
 
       - name: Set result
         id: result

--- a/.github/workflows/validate-resource-types.yaml
+++ b/.github/workflows/validate-resource-types.yaml
@@ -10,6 +10,9 @@ on:
       - "**/test/app.bicep"
       - "**/*.yaml"
       - ".github/workflows/validate-resource-types.yaml"
+      - ".github/scripts/**"
+      - ".github/build/**"
+      - "Makefile"
   # NOTE: No paths filter on pull_request. The "check-paths" job below determines
   # whether resource type or recipe files changed. When they haven't, the
   # "skip-validation" job reports the required check names so branch protection is
@@ -54,6 +57,9 @@ jobs:
             **/test/app.bicep
             **/*.yaml
             .github/workflows/validate-resource-types.yaml
+            .github/scripts/**
+            .github/build/**
+            Makefile
 
       - name: Set result
         id: result

--- a/.github/workflows/validate-resource-types.yaml
+++ b/.github/workflows/validate-resource-types.yaml
@@ -13,10 +13,8 @@ on:
       - ".github/scripts/**"
       - ".github/build/**"
       - "Makefile"
-  # NOTE: No paths filter on pull_request. The "check-paths" job below determines
-  # whether resource type or recipe files changed. When they haven't, the
-  # "skip-validation" job reports the required check names so branch protection is
-  # satisfied without running the full validation suite.
+  # No paths filter on pull_request: these are local (k3d) tests with no cloud
+  # cost, so the workflow runs on every PR and the required checks always report.
   pull_request:
     branches: [main]
   merge_group:
@@ -32,68 +30,7 @@ on:
 permissions: {}
 
 jobs:
-  # Detect whether resource type or recipe files changed. For non-PR events
-  # (merge_group, workflow_dispatch) the output defaults to 'true' so validation
-  # always runs.
-  check-paths:
-    name: Check Paths
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    permissions:
-      pull-requests: read
-    outputs:
-      files-changed: ${{ steps.result.outputs.files-changed }}
-    steps:
-      # REST API mode: no checkout needed, works with fork PRs. Only supports
-      # pull_request events — non-PR events skip this and default to files-changed=true.
-      - name: Detect resource type and recipe file changes
-        id: filter
-        if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
-        with:
-          use_rest_api: true
-          files: |
-            **/kubernetes/**
-            **/test/app.bicep
-            **/*.yaml
-            .github/workflows/validate-resource-types.yaml
-            .github/scripts/**
-            .github/build/**
-            Makefile
-
-      - name: Set result
-        id: result
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          ANY_MODIFIED: ${{ steps.filter.outputs.any_modified }}
-        run: |
-          set -euo pipefail
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            echo "files-changed=$ANY_MODIFIED" >> "$GITHUB_OUTPUT"
-          else
-            echo "Non-PR event — assuming files changed"
-            echo "files-changed=true" >> "$GITHUB_OUTPUT"
-          fi
-
-  # When no resource type or recipe files changed, report the required check names
-  # as successful so that branch protection is satisfied.
-  skip-validation:
-    needs: [check-paths]
-    if: needs.check-paths.outputs.files-changed != 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    name: Validate Resource Types and Recipes
-    strategy:
-      matrix:
-        recipe: [bicep, terraform]
-    permissions: {}
-    steps:
-      - name: Skip
-        run: echo "No resource type or recipe files changed — skipping ${{ matrix.recipe }} validation"
-
   validate-resource-types:
-    needs: [check-paths]
-    if: needs.check-paths.outputs.files-changed == 'true'
     name: Validate Resource Types and Recipes
     runs-on: ubuntu-24.04
     timeout-minutes: 30

--- a/.github/workflows/validate-resource-types.yaml
+++ b/.github/workflows/validate-resource-types.yaml
@@ -10,13 +10,12 @@ on:
       - "**/test/app.bicep"
       - "**/*.yaml"
       - ".github/workflows/validate-resource-types.yaml"
+  # NOTE: No paths filter on pull_request. The "check-paths" job below determines
+  # whether resource type or recipe files changed. When they haven't, the
+  # "skip-validation" job reports the required check names so branch protection is
+  # satisfied without running the full validation suite.
   pull_request:
     branches: [main]
-    paths:
-      - "**/kubernetes/**"
-      - "**/test/app.bicep"
-      - "**/*.yaml"
-      - ".github/workflows/validate-resource-types.yaml"
   merge_group:
     types: [checks_requested]
   workflow_dispatch:
@@ -30,7 +29,65 @@ on:
 permissions: {}
 
 jobs:
+  # Detect whether resource type or recipe files changed. For non-PR events
+  # (merge_group, workflow_dispatch) the output defaults to 'true' so validation
+  # always runs.
+  check-paths:
+    name: Check Paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      files-changed: ${{ steps.result.outputs.files-changed }}
+    steps:
+      # REST API mode: no checkout needed, works with fork PRs. Only supports
+      # pull_request events — non-PR events skip this and default to files-changed=true.
+      - name: Detect resource type and recipe file changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          use_rest_api: true
+          files: |
+            **/kubernetes/**
+            **/test/app.bicep
+            **/*.yaml
+            .github/workflows/validate-resource-types.yaml
+
+      - name: Set result
+        id: result
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ANY_MODIFIED: ${{ steps.filter.outputs.any_modified }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            echo "files-changed=$ANY_MODIFIED" >> "$GITHUB_OUTPUT"
+          else
+            echo "Non-PR event — assuming files changed"
+            echo "files-changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # When no resource type or recipe files changed, report the required check names
+  # as successful so that branch protection is satisfied.
+  skip-validation:
+    needs: [check-paths]
+    if: needs.check-paths.outputs.files-changed != 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    name: Validate Resource Types and Recipes
+    strategy:
+      matrix:
+        recipe: [bicep, terraform]
+    permissions: {}
+    steps:
+      - name: Skip
+        run: echo "No resource type or recipe files changed — skipping ${{ matrix.recipe }} validation"
+
   validate-resource-types:
+    needs: [check-paths]
+    if: needs.check-paths.outputs.files-changed == 'true'
     name: Validate Resource Types and Recipes
     runs-on: ubuntu-24.04
     timeout-minutes: 30


### PR DESCRIPTION
## Problem

The `main` ruleset requires four status checks. Two of them — `Validate Resource Types and Recipes (bicep)` and `Validate Resource Types and Recipes (terraform)` — are produced by `validate-resource-types.yaml`, which filtered its `pull_request` trigger by `paths`.

When a PR changes no files matching those paths, the workflow never runs, so those required checks are never reported. The PR then sits on **"Expected — Waiting for status to be reported"** indefinitely and cannot merge.

For example, #182 only touches `.github/scripts/generate-recipe-pack.sh` and a `README.md`, neither of which matched the path filter, so its required Resource Types checks never reported.

## Fix

### 1. Always run resource type validation on PRs (`validate-resource-types.yaml`)

Resource type validation runs on a local k3d cluster with no cloud cost, so the simplest robust fix is to **just run it on every PR**: the required checks are then satisfied directly, with no risk of a skip job reporting a false green when an untested file changes.

- **Removed the `paths:` filter from the `pull_request` trigger** so the workflow runs on every PR.

(The `push`-to-`main` trigger keeps a `paths:` filter to avoid redundant post-merge runs.)

### 2. Trigger post-merge validation on build-tooling changes (both workflows)

The recipe validation logic lives in `.github/scripts/**`, `.github/build/*.mk`, and the `Makefile` (e.g. `make generate-recipe-pack` → `generate-recipe-pack.sh`). Added `.github/scripts/**`, `.github/build/**`, and `Makefile` to the `push` paths filter of both workflows, and to the `check-paths` detection of the Azure workflow.

### Note on the Azure workflow

`validate-azure-recipes.yaml` keeps its `check-paths` / `skip-validation` pattern (added in #168): Azure tests provision real, paid cloud resources, so we don't want to run them on every PR. That pattern reports the required Azure check names as passing when no Azure files changed.

## Validation

- `actionlint` passes on both workflows with no issues.
- YAML parses cleanly.

## Notes

- This takes effect for PRs once merged to `main`. Open PRs (e.g. #182) will need a rebase to pick it up.