### PR TITLE
Replace secretName with a secrets array on postgreSqlDatabases and mySqlDatabases

### DIFF
--- a/Data/mySqlDatabases/mySqlDatabases.yaml
+++ b/Data/mySqlDatabases/mySqlDatabases.yaml
@@ -2,14 +2,16 @@ namespace: Radius.Data
 types:
   mySqlDatabases:
     description: |
-      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database. To deploy a new MySQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a mySqlDatabases resource referencing the secret name.
+      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database. To deploy a new MySQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a mySqlDatabases resource listing that secret in its `secrets` array.
       ```
       resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
         name: 'mysql'
         properties: {
           environment: environment
           application: myApplication.id
-          secretName: dbCredentials.name
+          secrets: [
+            dbCredentials.id
+          ]
         }
       }
       
@@ -19,11 +21,11 @@ types:
           environment: environment
           application: myApplication.id
           data: {
-            USERNAME: {
+            username: {
               value: 'admin'
             }
-            PASSWORD: {
-              # From password parameter passed in via CLI
+            password: {
+              // From password parameter passed in via CLI
               value: password
             }
           }
@@ -79,9 +81,13 @@ types:
             database:
               type: string
               description: "(Optional) The name of the database. Defaults to `mysql_db` if not provided."
-            secretName:
-              type: string
-              description: "(Required) The name of the secret containing the database credentials."
+            secrets:
+              type: array
+              x-radius-secret-binding: true
+              description: "(Required) The Radius.Security/secrets resources holding the credentials this database needs. Each entry is a secret resource ID (for example `dbSecret.id`). Radius loads every key of each listed secret and exposes it to the recipe as `{{context.resource.secrets.<secretName>.<key>}}`, where `<secretName>` is the secret resource's name and `<key>` is a key in its `data`."
+              items:
+                type: string
+                description: "The resource ID of a Radius.Security/secrets resource (for example `dbSecret.id`)."
             version:
               type: string
               enum: ['5.7', '8.0', '8.4']
@@ -94,4 +100,4 @@ types:
               type: integer
               description: "(Read-only) The port number used to connect to the database."
               readOnly: true
-          required: [environment,secretName]
+          required: [environment,secrets]

--- a/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
+++ b/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
@@ -2,7 +2,7 @@ namespace: Radius.Data
 types:
   postgreSqlDatabases:  
     description: |
-      The Radius.Data/postgreSqlDatabases Resource Type deploys a PostgreSQL database. To deploy a PostgreSQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a postgreSqlDatabases resource referencing the secret name.
+      The Radius.Data/postgreSqlDatabases Resource Type deploys a PostgreSQL database. To deploy a PostgreSQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a postgreSqlDatabases resource listing that secret in its `secrets` array.
       ```
       resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
           name: 'postgresql'
@@ -10,7 +10,9 @@ types:
             environment: environment
             application: myApplication.id
             size: 'S'
-            secretName: dbCredentials.name
+            secrets: [
+              dbCredentials.id
+            ]
           }
         }
 
@@ -81,10 +83,13 @@ types:
               type: string
               enum: ['S', 'M', 'L']
               description: "(Optional) The size of the PostgreSQL database. Defaults to `S` if not provided."
-            secretName:
-              type: string
-              x-radius-secret-reference: true
-              description: "(Required) The name of the secret containing the database credentials."
+            secrets:
+              type: array
+              x-radius-secret-binding: true
+              description: "(Required) The Radius.Security/secrets resources holding the credentials this database needs. Each entry is a secret resource ID (for example `dbSecret.id`). Radius loads every key of each listed secret and exposes it to the recipe as `{{context.resource.secrets.<secretName>.<key>}}`, where `<secretName>` is the secret resource's name and `<key>` is a key in its `data`."
+              items:
+                type: string
+                description: "The resource ID of a Radius.Security/secrets resource (for example `dbSecret.id`)."
             database:
               type: string
               description: "(Optional) The name of the database. Defaults to `postgres_db` if not provided."
@@ -99,4 +104,4 @@ types:
               type: string
               description: The port number used to connect to the database.
               readOnly: true
-          required: [environment,secretName]
+          required: [environment,secrets]

--- a/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
+++ b/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
@@ -83,6 +83,7 @@ types:
               description: "(Optional) The size of the PostgreSQL database. Defaults to `S` if not provided."
             secretName:
               type: string
+              x-radius-secret-reference: true
               description: "(Required) The name of the secret containing the database credentials."
             database:
               type: string


### PR DESCRIPTION
## Description

Replaces the single `secretName` string on `Radius.Data/postgreSqlDatabases` **and** `Radius.Data/mySqlDatabases` with a `secrets` **array** annotated `x-radius-secret-binding: true`. Each entry is the resource ID of a `Radius.Security/secrets` resource (for example `dbSecret.id`):

```bicep
resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
  name: 'postgresql'
  properties: {
    environment: environment
    application: myApplication.id
    size: 'S'
    secrets: [
      dbCredentials.id
    ]
  }
}
```

The `mySqlDatabases` change is identical in shape (same `secrets` array, same annotation, same `required` update).

Radius recognizes a property carrying this annotation as a list of secret bindings. For every listed secret it loads **all** of the secret's keys and exposes them to direct-module recipes as `{{context.resource.secrets.<secretName>.<key>}}`, where `<secretName>` is the secret resource's name and `<key>` is a key in its `data`. Platform recipes therefore consume real credentials without the developer ever placing them in the app definition.

Why an array of resource IDs instead of a single name string:

- **Natural, scalable shape.** A database may need more than one secret (credentials, TLS material, …). A list of resource IDs handles that; a single magic name string does not.
- **Consistent with `connections`.** Developers already reference other resources by `.id`; secrets now follow the same convention.
- **Namespaced, collision-free.** Recipe references are qualified by secret name (`...secrets.<secretName>.<key>`), so multiple bound secrets never clash.

`required` is updated from `[environment, secretName]` to `[environment, secrets]` on both types. This is a metadata + schema-shape change to one existing property; the types' recipes are otherwise unchanged.

> [!IMPORTANT]
> This depends on the engine support added in radius-project/radius#12254, which introduces the `x-radius-secret-binding` annotation and the `{{context.resource.secrets.<secretName>.<key>}}` resolution path. The annotation is inert on engine versions without it, so this PR stays a **draft** until #12254 lands. Design context: radius-project/radius#12244.

Related GitHub Issue: N/A (tracked in radius-project/radius#12244 and #12254)

## Testing

Exercised end-to-end by the manual resource-type verification workflow in [`radius-project/resource-types-verification`](https://github.com/radius-project/resource-types-verification) — the Azure (Bicep AVM) direct-module flow registers each manifest, deploys a `postgreSqlDatabases` / `mySqlDatabases` resource whose `secrets` array points at a `Radius.Security/secrets` resource, and proves the injected secret value reaches the cloud database (the server's `administratorLogin` read-back matches the secret's username), then validates delete.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] All properties in the Resource Type definition have clear descriptions
- [x] Required properties are listed in `required: []` for every object property
- [x] Properties about the deployed resource are defined as read-only (`readOnly: true`)
- [ ] Resource types and recipes were tested <!-- pending #12254; validated via resource-types-verification once the engine support lands -->

<sub>Remaining checklist items (README docs, developer documentation, recipe authoring/idempotency, `rad resource-type show`) are unchanged from `main` — this PR only changes a single property's shape on two existing types.</sub>