### PR TITLE
Bind Radius.Security/secrets to postgreSqlDatabases and mySqlDatabases, retained at rest

### DIFF
--- a/Data/mySqlDatabases/mySqlDatabases.yaml
+++ b/Data/mySqlDatabases/mySqlDatabases.yaml
@@ -2,14 +2,16 @@ namespace: Radius.Data
 types:
   mySqlDatabases:
     description: |
-      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database. To deploy a new MySQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a mySqlDatabases resource referencing the secret name.
+      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database. To deploy a new MySQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a mySqlDatabases resource listing that secret in its `secrets` array.
       ```
       resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
         name: 'mysql'
         properties: {
           environment: environment
           application: myApplication.id
-          secretName: dbCredentials.name
+          secrets: [
+            dbCredentials.id
+          ]
         }
       }
       
@@ -19,11 +21,11 @@ types:
           environment: environment
           application: myApplication.id
           data: {
-            USERNAME: {
+            username: {
               value: 'admin'
             }
-            PASSWORD: {
-              # From password parameter passed in via CLI
+            password: {
+              // From password parameter passed in via CLI
               value: password
             }
           }
@@ -79,9 +81,13 @@ types:
             database:
               type: string
               description: "(Optional) The name of the database. Defaults to `mysql_db` if not provided."
-            secretName:
-              type: string
-              description: "(Required) The name of the secret containing the database credentials."
+            secrets:
+              type: array
+              x-radius-secret-binding: true
+              description: "(Required) The Radius.Security/secrets resources holding the credentials this database needs. Each entry is a secret resource ID (for example `dbSecret.id`). Radius loads every key of each listed secret and exposes it to the recipe as `{{context.resource.secrets.<secretName>.<key>}}`, where `<secretName>` is the secret resource's name and `<key>` is a key in its `data`."
+              items:
+                type: string
+                description: "The resource ID of a Radius.Security/secrets resource (for example `dbSecret.id`)."
             version:
               type: string
               enum: ['5.7', '8.0', '8.4']
@@ -94,4 +100,4 @@ types:
               type: integer
               description: "(Read-only) The port number used to connect to the database."
               readOnly: true
-          required: [environment,secretName]
+          required: [environment,secrets]

--- a/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
+++ b/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
@@ -2,7 +2,7 @@ namespace: Radius.Data
 types:
   postgreSqlDatabases:  
     description: |
-      The Radius.Data/postgreSqlDatabases Resource Type deploys a PostgreSQL database. To deploy a PostgreSQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a postgreSqlDatabases resource referencing the secret name.
+      The Radius.Data/postgreSqlDatabases Resource Type deploys a PostgreSQL database. To deploy a PostgreSQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a postgreSqlDatabases resource listing that secret in its `secrets` array.
       ```
       resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
           name: 'postgresql'
@@ -10,7 +10,9 @@ types:
             environment: environment
             application: myApplication.id
             size: 'S'
-            secretName: dbCredentials.name
+            secrets: [
+              dbCredentials.id
+            ]
           }
         }
 
@@ -81,10 +83,13 @@ types:
               type: string
               enum: ['S', 'M', 'L']
               description: "(Optional) The size of the PostgreSQL database. Defaults to `S` if not provided."
-            secretName:
-              type: string
-              x-radius-secret-reference: true
-              description: "(Required) The name of the secret containing the database credentials."
+            secrets:
+              type: array
+              x-radius-secret-binding: true
+              description: "(Required) The Radius.Security/secrets resources holding the credentials this database needs. Each entry is a secret resource ID (for example `dbSecret.id`). Radius loads every key of each listed secret and exposes it to the recipe as `{{context.resource.secrets.<secretName>.<key>}}`, where `<secretName>` is the secret resource's name and `<key>` is a key in its `data`."
+              items:
+                type: string
+                description: "The resource ID of a Radius.Security/secrets resource (for example `dbSecret.id`)."
             database:
               type: string
               description: "(Optional) The name of the database. Defaults to `postgres_db` if not provided."
@@ -99,4 +104,4 @@ types:
               type: string
               description: The port number used to connect to the database.
               readOnly: true
-          required: [environment,secretName]
+          required: [environment,secrets]

--- a/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
+++ b/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
@@ -83,6 +83,7 @@ types:
               description: "(Optional) The size of the PostgreSQL database. Defaults to `S` if not provided."
             secretName:
               type: string
+              x-radius-secret-reference: true
               description: "(Required) The name of the secret containing the database credentials."
             database:
               type: string

--- a/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
+++ b/Data/postgreSqlDatabases/postgreSqlDatabases.yaml
@@ -2,7 +2,7 @@ namespace: Radius.Data
 types:
   postgreSqlDatabases:  
     description: |
-      The Radius.Data/postgreSqlDatabases Resource Type deploys a PostgreSQL database. To deploy a PostgreSQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a postgreSqlDatabases resource listing that secret in its `secrets` array.
+      The Radius.Data/postgreSqlDatabases Resource Type deploys a PostgreSQL database. Provide the administrator `username` and `password` directly on the resource. The `password` property is marked `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and exposes it (decrypted) only to the recipe that provisions the database.
       ```
       resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
           name: 'postgresql'
@@ -10,30 +10,14 @@ types:
             environment: environment
             application: myApplication.id
             size: 'S'
-            secrets: [
-              dbCredentials.id
-            ]
-          }
-        }
-
-        resource dbCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
-          name: 'db-creds'
-          properties: {
-            environment: environment
-            application: myApplication.id
-            data: {
-              username: {
-                value: 'admin'
-              }
-              password: {
-                // From password parameter passed in via CLI
-                value: password
-              }
-            }
+            database: 'appdb'
+            username: 'myadmin'
+            // From a @secure() password parameter passed in via the CLI
+            password: password
           }
         }
       ```
-      
+
       When deploying the application definition, provide the database password value as a parameter. It is recommended to use a password generator such as `openssl` or equivalent. For example, `rad deploy app.bicep -p password=$(openssl rand -hex 16)`.
 
       To connect your container to the database, create a connection from the Container resource to the database as shown below. 
@@ -83,10 +67,17 @@ types:
               type: string
               enum: ['S', 'M', 'L']
               description: "(Optional) The size of the PostgreSQL database. Defaults to `S` if not provided."
+            username:
+              type: string
+              description: "(Required) The administrator username for the PostgreSQL database. Provided directly on the resource and passed to the recipe as `{{context.resource.properties.username}}`."
+            password:
+              type: string
+              x-radius-sensitive: true
+              description: "(Required) The administrator password for the PostgreSQL database. Marked `x-radius-sensitive`: Radius encrypts it at rest, redacts it on reads, and exposes it decrypted only to the recipe as `{{context.resource.properties.password}}`."
             secrets:
               type: array
               x-radius-secret-binding: true
-              description: "(Required) The Radius.Security/secrets resources holding the credentials this database needs. Each entry is a secret resource ID (for example `dbSecret.id`). Radius loads every key of each listed secret and exposes it to the recipe as `{{context.resource.secrets.<secretName>.<key>}}`, where `<secretName>` is the secret resource's name and `<key>` is a key in its `data`."
+              description: "(Optional, legacy) An alternative to the direct `username`/`password` properties: a list of Radius.Security/secrets resource IDs holding the credentials this database needs (for example `dbSecret.id`). Radius loads every key of each listed secret and exposes it to the recipe as `{{context.resource.secrets.<secretName>.<key>}}`, where `<secretName>` is the secret resource's name and `<key>` is a key in its `data`."
               items:
                 type: string
                 description: "The resource ID of a Radius.Security/secrets resource (for example `dbSecret.id`)."
@@ -104,4 +95,4 @@ types:
               type: string
               description: The port number used to connect to the database.
               readOnly: true
-          required: [environment,secrets]
+          required: [environment,username,password]

--- a/Security/secrets/secrets.yaml
+++ b/Security/secrets/secrets.yaml
@@ -77,6 +77,7 @@ types:
                   value:
                     type: string
                     x-radius-sensitive: true
+                    x-radius-retain: true
                     description: (Required) The string value of the secret unless encoding is set to 'base64'.
                 required: [value]
           required:


### PR DESCRIPTION
## Description

Two related changes that let developers hand secrets to direct-module recipes, consolidated from the previously stacked draft #193:

### 1. `secretName` → a `secrets` array on `postgreSqlDatabases` and `mySqlDatabases`

Replaces the single `secretName` string on `Radius.Data/postgreSqlDatabases` **and** `Radius.Data/mySqlDatabases` with a `secrets` **array** annotated `x-radius-secret-binding: true`. Each entry is the resource ID of a `Radius.Security/secrets` resource (for example `dbSecret.id`):

```bicep
resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
  name: 'postgresql'
  properties: {
    environment: environment
    application: myApplication.id
    size: 'S'
    secrets: [
      dbCredentials.id
    ]
  }
}
```

Radius recognizes a property carrying this annotation as a list of secret bindings. For every listed secret it loads **all** of the secret's keys and exposes them to direct-module recipes as `{{context.resource.secrets.<secretName>.<key>}}`. Platform recipes therefore consume real credentials without the developer ever placing them in the app definition. `required` is updated from `[environment, secretName]` to `[environment, secrets]` on both types.

Why an array of resource IDs instead of a single name string:

- **Natural, scalable shape.** A database may need more than one secret (credentials, TLS material, …).
- **Consistent with `connections`.** Developers already reference other resources by `.id`.
- **Namespaced, collision-free.** References are qualified by secret name (`...secrets.<secretName>.<key>`), so multiple bound secrets never clash.

### 2. Mark `Radius.Security/secrets` values `x-radius-retain`

Adds `x-radius-retain: true` to the secret `value` field (already `x-radius-sensitive`). This keeps the canonical contrib definition in sync with the built-in type: the **encrypted** value is retained at rest (still redacted on GET/LIST) so recipes can decrypt it from Radius's own store rather than reading a Kubernetes Secret — required for multi-cluster-safe secret resolution.

> [!IMPORTANT]
> Depends on the engine support in radius-project/radius (the `x-radius-secret-binding` resolution path and `x-radius-retain` persistence). The annotations are inert on engine versions without it, so this stays a **draft** until the radius change lands. Design context: radius-project/radius#12244.

Related GitHub Issue: N/A (tracked in radius-project/radius#12244)

## Testing

Exercised end-to-end by the manual resource-type verification workflow in [`radius-project/resource-types-verification`](https://github.com/radius-project/resource-types-verification) — the Azure (Bicep AVM) direct-module flow registers each manifest, deploys a `postgreSqlDatabases` resource whose `secrets` array points at a `Radius.Security/secrets` resource, and proves the injected secret value (retained encrypted at rest, decrypted from Radius's store) reaches the real Azure database, then validates delete.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] All properties in the Resource Type definition have clear descriptions
- [x] Required properties are listed in `required: []` for every object property
- [x] Properties about the deployed resource are defined as read-only (`readOnly: true`)
- [ ] Resource types and recipes were tested <!-- validated via resource-types-verification once the radius engine support lands -->
