### PR TITLE
Resolve ${connection:<key>.<prop>} sentinels in container env values

### DIFF
--- a/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+++ b/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
@@ -111,6 +111,34 @@ var connectionEnvVars = reduce(items(resourceConnections), [], (acc, conn) =>
     : acc
 )
 
+// Token table for ${connection:<key>.<prop>} sentinels used in container env values. Uses the same
+// decrypted source (resourceConnections) and the same exclusions as connectionEnvVars, so any connected
+// resource property (top-level or nested `properties` bag) can be referenced by name in an env value and
+// is resolved to its real (decrypted) value — without the fixed CONNECTION_<KEY>_<PROP> naming.
+var connectionTokens = reduce(items(resourceConnections), [], (acc, conn) =>
+  !isSecretsResource[conn.key] && connectionDefinitions[conn.key].?disableDefaultEnvVars != true
+    ? concat(
+        acc,
+        reduce(items(conn.value ?? {}), [], (tokenAcc, prop) =>
+          (prop.key == 'properties' || prop.key == 'secretName' || contains(excludedProperties, prop.key))
+            ? tokenAcc
+            : concat(tokenAcc, [{
+                token: concat('$', '{connection:', conn.key, '.', prop.key, '}')
+                value: string(prop.value)
+              }])
+        ),
+        reduce(items(conn.value.?properties ?? {}), [], (tokenAcc, prop) =>
+          (prop.key == 'secretName' || contains(excludedProperties, prop.key))
+            ? tokenAcc
+            : concat(tokenAcc, [{
+                token: concat('$', '{connection:', conn.key, '.', prop.key, '}')
+                value: string(prop.value)
+              }])
+        )
+      )
+    : acc
+)
+
 // Use replicas from properties, default to 1 if not specified
 var replicaCount = resourceProperties.?replicas != null ? int(resourceProperties.replicas) : 1
 
@@ -139,7 +167,7 @@ var containerSpecs = reduce(containerItems, [], (acc, item) => concat(acc, [{
           {
             name: envItem.key
           },
-          contains(envItem.value, 'value') ? { value: envItem.value.value } : {},
+          contains(envItem.value, 'value') ? { value: reduce(connectionTokens, string(envItem.value.value), (acc, t) => replace(string(acc), t.token, t.value)) } : {},
           (contains(envItem.value, 'valueFrom') && contains(envItem.value.valueFrom, 'secretKeyRef')) ? {
             valueFrom: {
               secretKeyRef: {


### PR DESCRIPTION
## What

Teaches the Kubernetes `Radius.Compute/containers` recipe to resolve `${connection:<key>.<prop>}` **sentinels** placed in a container env `value`. A new `connectionTokens` table is built from the same decrypted `resourceConnections` (and the same exclusions) as the existing `connectionEnvVars`, then each env `value` is passed through a `reduce(... replace ...)` that substitutes any sentinel with the connected resource's real property value. Both top-level connection properties and the nested `properties` bag are covered.

```bicep
env: {
  API_KEY: { value: '${connection:provider.apiKey}' }
}
```

## Why

Today an application can only receive connected-resource properties under the fixed `CONNECTION_<KEY>_<PROP>` names. Apps that expect a specific env var name (e.g. a third-party image) otherwise need a per-app **startup shim** or a custom image to remap the value. The sentinel lets the app author name the target env var directly and pull any single property — including a **sensitive** property that is delivered *decrypted* through connection injection — with no shim and no custom image.

## Backward compatibility

- Env values with no sentinel pass through unchanged.
- Secrets-resource connections and `disableDefaultEnvVars` are skipped exactly as for the default connection env vars.

## Dependency

The sensitive-value path relies on the connection being delivered **decrypted** at runtime, which comes from radius-project/radius#12286 (connection-injection decrypt + `x-radius-retain`). Non-sensitive properties resolve on radius `main` today; sensitive ones require #12286. Marking this **draft** until #12286 lands.

## Verification

Proven end-to-end by a cloud-free kind-only test in `resource-types-verification`: a synthetic connected resource exposes a non-sensitive canary and a sensitive (`x-radius-sensitive` + `x-radius-retain`) canary; a busybox container consumes both via sentinels. The resolved Deployment-spec env showed the plain canary **and** the sensitive canary delivered decrypted:

```
PASS: plain sentinel resolved to the connection value
PASS: sensitive sentinel resolved to the DECRYPTED connection value
```
