### PR TITLE
Add mySqlDatabases Azure Recipe Pack and adopt the Recipe Pack model

### DIFF
--- a/Data/mySqlDatabases/README.md
+++ b/Data/mySqlDatabases/README.md
@@ -2,31 +2,31 @@
 
 ## Overview
 
-The **Radius.Data/mySqlDatabases** resource type represents a MySQL database. It allows developers to create and easily connect to a MySQL database as part of their Radius applications.
+The **Radius.Data/mySqlDatabases** resource type represents a MySQL database. It allows developers to create and easily connect to a MySQL database as part of their Radius applications. The developer provides the administrator `username` and `password` directly on the resource; the `password` property is marked `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and injects it decrypted only into the platform's Recipe.
 
-Developer documentation is embedded in the resource type definition YAML file, and it is accessible via the `rad resource-type show Radius.Data/mySqlDatabases` command.
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.Data/mySqlDatabases` command.
 
-## Recipes
+## Properties
 
-A list of available Recipes for this resource type, including links to the Bicep and Terraform templates:
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `username` | string | Required | The administrator username for the MySQL database. Passed to the Recipe as `{{context.resource.properties.username}}`. |
+| `password` | string (`x-radius-sensitive`) | Required | The administrator password. Encrypted at rest, redacted on reads, and injected decrypted into the Recipe as `{{context.resource.properties.password}}`. |
+| `database` | string | Optional | The name of the database. Defaults to `mysql_db`. |
+| `version` | string (`5.7`, `8.0`, `8.4`) | Optional | The major MySQL server version. Defaults to `8.4`. |
+| `host` | string | Read only | The host name used to connect to the database. Set from the Recipe module's output. |
+| `port` | integer | Read only | The port number used to connect to the database. Set from the Recipe module's output. |
 
-|Platform| IaC Language| Recipe Name | Stage | Recipe parameters|
-|--------|-------------|-------------|-------|------------------|
-| Kubernetes | Bicep | kubernetes-mysql.bicep | Alpha | |
-| AWS | Terraform | main.tf | Alpha | VPC ID, Subnet IDs|
+## Recipe Packs
 
-## Recipe Input Properties
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.Data/mySqlDatabases` along with the Recipes for every other Resource Type on that platform.
 
-Properties for the **Radius.Data/mySqlDatabases** resource type are provided via the [Recipe Context](https://docs.radapp.io/reference/context-schema/) object. These properties include:
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `avm/res/db-for-my-sql/flexible-server` |
 
-- `context.resource.properties.database`(string, optional): The name of the database. Defaults to `mysql_db` if not provided.
-- `context.resource.properties.secretName`(string, required): Name of the secret containing the database credentials.
-- `context.resource.properties.version`(string, optional): The major MySQL server version in the X.Y format. Defaults to the version `8.4` if not provided.
+## Using the resource type
 
-## Recipe Output Properties
-
-The **Radius.Data/mySqlDatabases** resource type expects the following output properties to be set in the Results object in the Recipe:
-
-- `context.resource.properties.host` (string): The hostname used to connect to the database.
-- `context.resource.properties.port` (integer): The port number used to connect to the database.
-- `context.resource.properties.database` (string): The name of the database.
+Add a `mySqlDatabases` resource to your application and connect a container to it. Radius injects the database's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_MYSQLDB_HOST`, `CONNECTION_MYSQLDB_PORT`, and `CONNECTION_MYSQLDB_DATABASE`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Data/mySqlDatabases/mySqlDatabases.yaml
+++ b/Data/mySqlDatabases/mySqlDatabases.yaml
@@ -2,38 +2,25 @@ namespace: Radius.Data
 types:
   mySqlDatabases:
     description: |
-      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database. To deploy a new MySQL database, first add a secret resource with the database credentials to the application definition Bicep file, then add a mySqlDatabases resource referencing the secret name.
+      The Radius.Data/mySqlDatabases Resource Type deploys a MySQL database. Provide the administrator `username` and `password` directly on the resource. The `password` property is marked `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and exposes it (decrypted) only to the platform-engineer recipe that provisions the database.
       ```
       resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
         name: 'mysql'
         properties: {
           environment: environment
           application: myApplication.id
-          secretName: dbCredentials.name
-        }
-      }
-      
-      resource dbCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
-        name: 'db-creds'
-        properties: {
-          environment: environment
-          application: myApplication.id
-          data: {
-            USERNAME: {
-              value: 'admin'
-            }
-            PASSWORD: {
-              # From password parameter passed in via CLI
-              value: password
-            }
-          }
+          version: '8.0'
+          database: 'appdb'
+          username: 'myadmin'
+          // From a @secure() password parameter passed in via the CLI
+          password: password
         }
       }
       ```
 
-      When deploying the application definition, provide the database password value as a parameter. It is recommended to use a password generator such as `openssl` or equivalent. For example, `rad deploy app.bicep -p password=$(openssl rand -hex 16)`.
+      When deploying the application definition, provide the database password value as a parameter. It is recommended to use a password generator such as `openssl` or equivalent. For example, `rad deploy app.bicep -p ****** rand -hex 16)`.
 
-      To connect your container to the database, create a connection from the Container resource to the database as shown below. 
+      To connect your container to the database, create a connection from the Container resource to the database as shown below.
       ```
       resource myApplication 'Radius.Core/Applications@2025-08-01-preview' = { ... }
 
@@ -60,7 +47,7 @@ types:
       ```
 
       The connection automatically injects environment variables into the container for all properties from the database. The environment variables are named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example, the connection name is `mysqldb` so the environment variables will be:
- 
+
       - CONNECTION_MYSQLDB_DATABASE
       - CONNECTION_MYSQLDB_HOST
       - CONNECTION_MYSQLDB_PORT
@@ -72,26 +59,30 @@ types:
           properties:
             environment:
               type: string
-              description: "(Required) The Radius EnvironmentID. Typically set by the rad CLI. Typically value should be `environment`"
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
             application:
               type: string
               description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            username:
+              type: string
+              description: "(Required) The administrator username for the MySQL database. Provided directly on the resource and passed to the recipe as `{{context.resource.properties.username}}`."
+            password:
+              type: string
+              x-radius-sensitive: true
+              description: "(Required) The administrator password for the MySQL database. Marked `x-radius-sensitive`: Radius encrypts it at rest, redacts it on reads, and exposes it decrypted only to the recipe as `{{context.resource.properties.password}}`."
             database:
               type: string
               description: "(Optional) The name of the database. Defaults to `mysql_db` if not provided."
-            secretName:
-              type: string
-              description: "(Required) The name of the secret containing the database credentials."
             version:
               type: string
               enum: ['5.7', '8.0', '8.4']
-              description: "(Optional) The major MySQL server version in the X.Y format. Assumed to be 8.4 if not specified." 
+              description: "(Optional) The major MySQL server version in the X.Y format. Assumed to be 8.4 if not specified."
             host:
               type: string
-              description: "(Read-only) The host name used to connect to the database."
+              description: The host name used to connect to the database. Mapped from the recipe module's output.
               readOnly: true
             port:
               type: integer
-              description: "(Read-only) The port number used to connect to the database."
+              description: The port number used to connect to the database. Mapped from the recipe module's output (MySQL flexible server uses 3306).
               readOnly: true
-          required: [environment,secretName]
+          required: [environment,username,password]

--- a/Data/mySqlDatabases/test/app.bicep
+++ b/Data/mySqlDatabases/test/app.bicep
@@ -1,40 +1,38 @@
 extension radius
 
-@description('The Radius environment ID')
+extension mySqlDatabases
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 
+@description('Database admin password. Set on the resource `password` property (x-radius-sensitive), so Radius encrypts it at rest and injects it decrypted into the Recipe as the flexible server administrator password.')
 @secure()
 param password string
 
-resource myapp 'Radius.Core/applications@2025-08-01-preview' = {
-  name: 'myapp'
-  location: 'global'
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'mysql-azure-test'
   properties: {
     environment: environment
   }
 }
 
-resource dbSecret 'Radius.Security/secrets@2025-08-01-preview' = {
-  name: 'dbsecret'
+resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
+  name: 'mysql'
   properties: {
     environment: environment
-    application: myapp.id
-    data: {
-      USERNAME: {
-        value: 'admin'
-      }
-      PASSWORD: {
-        value: password
-      }
-    }
+    application: app.id
+    version: '8.0'
+    database: 'appdb'
+    username: 'radadmin'
+    password: password
   }
 }
 
-resource mycontainer 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'mycontainer'
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
   properties: {
     environment: environment
-    application: myapp.id
+    application: app.id
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
@@ -46,18 +44,9 @@ resource mycontainer 'Radius.Compute/containers@2025-08-01-preview' = {
       }
     }
     connections: {
-      mysql: {
+      mysqldb: {
         source: mysql.id
       }
     }
-  }
-}
-
-resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
-  name: 'mysql'
-  properties: {
-    environment: environment
-    application: myapp.id
-    secretName: dbSecret.name
   }
 }

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -1,0 +1,41 @@
+# Azure Recipe Pack
+
+This folder contains the **Azure Recipe Pack** — a collection of Recipes that provision Radius Resource Types on Azure, bundled with an Environment definition. Deploying the pack configures a Radius Environment to use the Azure provider and registers the Recipes for every Resource Type it covers.
+
+| File | Description |
+| --- | --- |
+| `bicep-recipepack.bicep` | Recipe Pack wiring the Bicep recipes for all Azure-provisioned types, plus the Environment definition. |
+
+Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, and a `Radius.Core/environments` resource that references the pack and configures the Azure provider.
+
+## Recipes in this pack
+
+| Resource Type | Kind | Source |
+| --- | --- | --- |
+| `Radius.Data/mySqlDatabases` | Bicep | Azure Verified Module — `avm/res/db-for-my-sql/flexible-server` |
+| `Radius.Compute/containers` | Bicep | `ghcr.io/radius-project/kube-recipes/containers` |
+
+## Parameters
+
+The Azure pack accepts the provider configuration it needs to provision into your subscription:
+
+| Parameter | Description |
+| --- | --- |
+| `azureSubscriptionId` | Azure subscription ID the Environment provisions resources into. |
+| `azureResourceGroup` | Existing Azure resource group the Environment provisions resources into. |
+
+## Deploying
+
+Deploy the pack with the `rad` CLI, supplying the parameters it requires. Deploying the file creates the `Radius.Core/recipePacks` resource and configures the `default` Environment to use it:
+
+```bash
+rad deploy recipepack/azure/bicep-recipepack.bicep \
+  --parameters azureSubscriptionId=<subscription-id> \
+  --parameters azureResourceGroup=<resource-group>
+```
+
+After the pack is deployed, every Resource Type it covers can be used in an application deployed to that Environment.
+
+## Contributing a Recipe
+
+To add a Recipe for another Resource Type to this pack, add an entry to the `recipes` map keyed by the Resource Type (for example `Radius.Data/mySqlDatabases`). For guidance on writing Recipes and wiring them into a Recipe Pack, see [Contributing Resource Types and Radius Recipes](../../docs/contributing/contributing-resource-types-recipes.md#recipes-and-recipe-packs).

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -1,0 +1,77 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'mysql-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/mySqlDatabases': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/db-for-my-sql/flexible-server:0.10.3'
+        parameters: {
+          name: '{{context.resource.name}}'
+          // Administrator credentials come directly from the developer-authored
+          // resource properties. `password` is x-radius-sensitive, so Radius exposes
+          // it decrypted to the recipe as {{context.resource.properties.password}}.
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+          // Cheapest Burstable SKU keeps provisioning quick and inexpensive.
+          skuName: 'Standard_B1ms'
+          tier: 'Burstable'
+          // Map the developer-authored `version` enum (5.7|8.0|8.4) onto a concrete
+          // MySQL server version. Azure MySQL flexible server supports 5.7 and
+          // 8.0.21, so anything other than 5.7 maps to 8.0.21.
+          version: '{{context.resource.properties.version == "5.7" ? "5.7" : "8.0.21"}}'
+          // Create the developer-authored database on the server.
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+            }
+          ]
+          // -1 = no hardcoded availability zone (required by the AVM).
+          availabilityZone: -1
+          // Burstable tier supports neither zone-redundant HA nor geo-redundant
+          // backup; both AVM defaults must be turned off.
+          highAvailability: 'Disabled'
+          geoRedundantBackup: 'Disabled'
+          storageSizeGB: 32
+          publicNetworkAccess: 'Enabled'
+          enableTelemetry: false
+        }
+        // Map the module's outputs onto the resource's properties. The AVM has no
+        // port output (MySQL flexible server is always 3306), so only `host` is
+        // mapped here, from the module's `fqdn` output.
+        outputs: {
+          host: 'fqdn'
+        }
+      }
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'default'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Brings the existing `Radius.Data/mySqlDatabases` resource type into the **Recipe Pack** model introduced for `redisCaches` in #199, and adds an Azure Recipe Pack that provisions MySQL via a direct Azure Verified Module.

### Resource type
- `Data/mySqlDatabases/mySqlDatabases.yaml` — switch the credential model to inline `username`/`password`, with `password` marked `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and injects it decrypted into the recipe as `{{context.resource.properties.username/password}}`. This replaces the previous `secretName` model and lets the direct-module recipe consume the credentials cleanly (mirroring how `redisCaches` maps `size`).
- `Data/mySqlDatabases/README.md` — revamped to the Recipe Pack model with a properties table.
- `Data/mySqlDatabases/test/app.bicep` — refreshed to the demo container + connection pattern.

### Recipe Packs
- `recipepack/azure/bicep-recipepack.bicep` — new Azure Recipe Pack wiring the `Radius.Data/mySqlDatabases` recipe to the AVM `avm/res/db-for-my-sql/flexible-server` direct module (plus the `Radius.Compute/containers` recipe and the `default` Environment). Maps the `version` enum onto a concrete server version and maps the module's `fqdn` output onto `host`.
- `recipepack/azure/README.md` — Recipe Pack overview and deploy instructions.

This Azure recipe has been validated end-to-end against real Azure via the direct-module feature (radius#12109) in the `resource-types-verification` workflows.

## Type of change

- Resource type update
- New Recipe Pack
- Documentation

## Notes

- Follows the same structure as #199, minus the one-time root-docs/Recipe-Pack-model revamp introduced there.
- The legacy `Data/mySqlDatabases/recipes/` directory is left in place because the `publish-bicep-recipes.yaml` workflow still references it.
- `recipepack/azure/` overlaps with #199; whichever merges second will need a trivial merge of the two `recipes` entries into the shared pack.
