### PR TITLE
Add kafka Azure Recipe Pack and adopt the Recipe Pack model

### DIFF
--- a/Messaging/kafka/README.md
+++ b/Messaging/kafka/README.md
@@ -1,0 +1,29 @@
+# Radius.Messaging/kafka
+
+## Overview
+
+The **Radius.Messaging/kafka** resource type represents a Kafka-compatible messaging namespace. It allows developers to create a topic and easily connect containers to the messaging endpoint as part of their Radius applications. The developer provides only the `topic` property; the platform Recipe provisions the backing service and maps read-only connection properties such as `host` and `connectionString` back onto the resource.
+
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.Messaging/kafka` command.
+
+## Properties
+
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `topic` | string | Optional | The Kafka topic/Event Hub name to create. Defaults to `events`. |
+| `host` | string | Read only | The host name used to connect to the Kafka-compatible endpoint. Set from the Recipe module's output. |
+| `connectionString` | string | Read only | The connection string used to connect to the Kafka-compatible endpoint. Set from the Recipe module's output. |
+
+## Recipe Packs
+
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.Messaging/kafka` along with the Recipes for every other Resource Type on that platform.
+
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `avm/res/event-hub/namespace` |
+
+## Using the resource type
+
+Add a `kafka` resource to your application and connect a container to it. Radius injects the Kafka connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_KAFKA_HOST` and `CONNECTION_KAFKA_CONNECTIONSTRING`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Messaging/kafka/kafka.yaml
+++ b/Messaging/kafka/kafka.yaml
@@ -1,0 +1,79 @@
+namespace: Radius.Messaging
+types:
+  kafka:
+    description: |
+      The Radius.Messaging/kafka Resource Type deploys a Kafka-compatible
+      messaging namespace. On Azure, the verification recipe provisions Azure
+      Event Hubs with its Kafka surface enabled by the Standard tier and creates
+      an Event Hub named by the developer-authored `topic` property.
+      ```
+      resource kafka 'Radius.Messaging/kafka@2025-08-01-preview' = {
+        name: 'kafka'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          topic: 'events'
+        }
+      }
+      ```
+
+      To connect a container to the cluster, create a connection from the
+      Container resource to the Kafka cluster as shown below.
+      ```
+      resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'frontend'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          container: {
+            image: 'frontend:1.25'
+          }
+          connections: {
+            kafka: {
+              source: kafka.id
+            }
+          }
+        }
+      }
+      ```
+
+      The connection automatically injects environment variables into the
+      container for all properties from the cluster. The environment variables are
+      named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example the
+      connection name is `kafka` so the environment variables will be:
+
+      - CONNECTION_KAFKA_HOST
+      - CONNECTION_KAFKA_CONNECTIONSTRING
+
+      Portability note: the schema is platform-neutral so the same type works
+      with Azure AVM (Bicep), AWS Terraform registry modules, and Kubernetes
+      recipes. Only the recipePack `source` plus `parameters`/`outputs` mapping
+      change per platform; the developer-facing properties (knobs and readOnly
+      connection surface) stay identical. For example, Azure maps `host` from the
+      Event Hubs namespace name while AWS MSK can map it from Terraform
+      `bootstrap_brokers`, and a Kubernetes Strimzi/Kafka recipe can map it from
+      the broker bootstrap Service DNS.
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
+            application:
+              type: string
+              description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            topic:
+              type: string
+              default: events
+              description: "(Optional) The Kafka topic/Event Hub name to create. Defaults to `events`."
+            host:
+              type: string
+              description: The host name used to connect to the Kafka-compatible endpoint. For Azure Event Hubs this is the namespace name; the bootstrap server is `<host>.servicebus.windows.net:9093`.
+              readOnly: true
+            connectionString:
+              type: string
+              description: The connection string used to connect to the Kafka-compatible endpoint. Mapped from the recipe module's output.
+              readOnly: true
+          required: [environment]

--- a/Messaging/kafka/test/app.bicep
+++ b/Messaging/kafka/test/app.bicep
@@ -1,0 +1,45 @@
+extension radius
+
+extension kafka
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'kafka-azure-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource kafkaBroker 'Radius.Messaging/kafka@2025-08-01-preview' = {
+  name: 'kafka'
+  properties: {
+    environment: environment
+    application: app.id
+    topic: 'events'
+  }
+}
+
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      demo: {
+        image: 'ghcr.io/radius-project/samples/demo:latest'
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      kafka: {
+        source: kafkaBroker.id
+      }
+    }
+  }
+}

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -1,0 +1,41 @@
+# Azure Recipe Pack
+
+This folder contains the **Azure Recipe Pack** — a collection of Recipes that provision Radius Resource Types on Azure, bundled with an Environment definition. Deploying the pack configures a Radius Environment to use the Azure provider and registers the Recipes for every Resource Type it covers.
+
+| File | Description |
+| --- | --- |
+| `bicep-recipepack.bicep` | Recipe Pack wiring the Bicep recipes for all Azure-provisioned types, plus the Environment definition. |
+
+Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, and a `Radius.Core/environments` resource that references the pack and configures the Azure provider.
+
+## Recipes in this pack
+
+| Resource Type | Kind | Source |
+| --- | --- | --- |
+| `Radius.Messaging/kafka` | Bicep | Azure Verified Module — `avm/res/event-hub/namespace` |
+| `Radius.Compute/containers` | Bicep | `ghcr.io/radius-project/kube-recipes/containers` |
+
+## Parameters
+
+The Azure pack accepts the provider configuration it needs to provision into your subscription:
+
+| Parameter | Description |
+| --- | --- |
+| `azureSubscriptionId` | Azure subscription ID the Environment provisions resources into. |
+| `azureResourceGroup` | Existing Azure resource group the Environment provisions resources into. |
+
+## Deploying
+
+Deploy the pack with the `rad` CLI, supplying the parameters it requires. Deploying the file creates the `Radius.Core/recipePacks` resource and configures the `default` Environment to use it:
+
+```bash
+rad deploy recipepack/azure/bicep-recipepack.bicep \
+  --parameters azureSubscriptionId=<subscription-id> \
+  --parameters azureResourceGroup=<resource-group>
+```
+
+After the pack is deployed, every Resource Type it covers can be used in an application deployed to that Environment.
+
+## Contributing a Recipe
+
+To add a Recipe for another Resource Type to this pack, add an entry to the `recipes` map keyed by the Resource Type (for example `Radius.Messaging/kafka`). For guidance on writing Recipes and wiring them into a Recipe Pack, see [Contributing Resource Types and Radius Recipes](../../docs/contributing/contributing-resource-types-recipes.md#recipes-and-recipe-packs).

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -1,0 +1,107 @@
+// Platform-engineer baseline for verifying Radius.Messaging/kafka on
+// Azure via a STANDARD Azure Verified Module (AVM) — no Radius wrapping, no
+// `context` parameter, no `result` output. Using the direct-module feature
+// (radius PR #12109) Radius:
+//   1. resolves any {{context.*}} expressions in `parameters` against the
+//      resource being deployed,
+//   2. runs the module through the existing Bicep driver + deployment engine,
+//      deploying to the environment's Azure subscription + resource group below
+//      with the credentials registered via `rad credential register azure sp`,
+//   3. maps the module's plain outputs onto the resource's properties via the
+//      `outputs` field (`connectionString` <- `primaryConnectionString`,
+//      `host` <- `name`).
+//
+// The AVM version is pinned with the standard Bicep/OCI `:<tag>` syntax.
+//
+// Portability: this developer-facing Radius type is intentionally platform-
+// neutral. Azure uses the Event Hubs namespace AVM below and maps `host` from the
+// namespace `name`; AWS can use an MSK Terraform registry module and map `host`
+// from `bootstrap_brokers`; Kubernetes can use a Strimzi/Kafka recipe and map
+// `host` from the broker bootstrap Service DNS. The schema and app.bicep stay
+// stable while only recipePack `source`, `parameters`, and `outputs` change.
+//
+// NOTE — API-COMPATIBILITY CAVEAT: Azure Event Hubs exposes a Kafka-compatible
+// endpoint but is NOT a full Apache Kafka broker. This verification therefore
+// proves provisioning, Radius output mapping, and Azure namespace existence only;
+// a real Kafka-client connectivity test is out of scope for this resource-type
+// verification because the stock demo container has no Kafka client.
+
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'kafka-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Messaging/kafka': {
+        kind: 'bicep'
+        // Standard Azure Verified Module, version pinned with `:<tag>`
+        // (https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/event-hub/namespace).
+        source: 'mcr.microsoft.com/bicep/avm/res/event-hub/namespace:0.14.2'
+        parameters: {
+          name: '{{context.resource.name}}'
+          // Azure Event Hubs Kafka protocol support requires Standard tier or higher.
+          skuName: 'Standard'
+          skuCapacity: 1
+          // The AVM defaults disableLocalAuth to TRUE, which turns off SAS-key (local)
+          // authentication for the namespace. The connection test's container authenticates
+          // over Kafka SASL/PLAIN using the SAS `primaryConnectionString`, so SAS auth MUST
+          // stay on. Leaving the default would also blank the RootManageSharedAccessKey keys,
+          // so the `primaryConnectionString` output comes back empty. Explicitly enable it.
+          disableLocalAuth: false
+          // Create the developer-authored topic as an Event Hub in the namespace.
+          eventhubs: [
+            {
+              name: '{{context.resource.properties.topic}}'
+            }
+          ]
+          // AVM modules emit a Microsoft.Resources/deployments telemetry resource
+          // the Radius Bicep deployment engine can't process at location "global".
+          // Disabling telemetry skips it — the AVM-sanctioned opt-out.
+          enableTelemetry: false
+        }
+        // Map the module's outputs onto the resource's properties.
+        // Keys are resource property names; values are module output names.
+        // `connectionString` is a SAS secret by nature, so the action asserts the
+        // `host` output mapping (the namespace name) as its provisioning check.
+        outputs: {
+          connectionString: 'primaryConnectionString'
+          host: 'name'
+        }
+      }
+      // Radius.Compute/containers is a default type but needs a recipe to deploy.
+      // The published Kubernetes container recipe materializes the Kafbat Kafka UI
+      // client (which connects to the Event Hubs Kafka endpoint over SASL_SSL) as a
+      // Kubernetes Deployment and wires the `connections` to the kafka resource.
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'default'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+      // The Radius.Compute/containers recipe provisions a Kubernetes Deployment in
+      // providers.kubernetes.namespace; `default` always exists in the kind cluster.
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds the `Radius.Messaging/kafka` resource type in the **Recipe Pack** model introduced for `redisCaches` in #199, and adds an Azure Recipe Pack that provisions Kafka-compatible messaging via a direct Azure Verified Module.

### Resource type
- `Messaging/kafka/kafka.yaml` — adds the validated `Radius.Messaging/kafka` schema. Developers set only the `topic` property; the recipe maps `host` and `connectionString` from the backing module outputs.
- `Messaging/kafka/README.md` — documents the Recipe Pack model with a properties table.
- `Messaging/kafka/test/app.bicep` — adds the demo container + connection pattern for the kafka resource.

### Recipe Packs
- `recipepack/azure/bicep-recipepack.bicep` — new Azure Recipe Pack wiring the `Radius.Messaging/kafka` recipe to the AVM `avm/res/event-hub/namespace` direct module (plus the `Radius.Compute/containers` recipe and the `default` Environment). Maps the developer-authored `topic` to an Event Hub, and maps the module's `primaryConnectionString` and `name` outputs onto `connectionString` and `host`.
- `recipepack/azure/README.md` — Recipe Pack overview and deploy instructions.

This Azure recipe has been validated end-to-end against real Azure via the direct-module feature in the `resource-types-verification` workflows.

## Type of change

- New resource type
- New Recipe Pack
- Documentation

## Notes

- Follows #199's structure minus the one-time root-docs revamp.
- `recipepack/azure/` overlaps with #199/#200, so whichever merges second needs a trivial merge of the `recipes` entries.
