### PR TITLE
Add search Azure Recipe Pack and adopt the Recipe Pack model

### DIFF
--- a/AI/search/README.md
+++ b/AI/search/README.md
@@ -1,0 +1,28 @@
+# Radius.AI/search
+
+## Overview
+
+The **Radius.AI/search** resource type represents a search service. It allows developers to create and connect to a search service as part of their Radius applications. The resource has no developer-authored credentials; the platform Recipe maps the provisioned service endpoint and API key back onto read-only resource properties for connections.
+
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.AI/search` command.
+
+## Properties
+
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `endpoint` | string | Read only | The endpoint used to connect to the search service. Set from the Recipe module's output. |
+| `apiKey` | string | Read only | The admin API key used to connect to the search service. Set from the Recipe module's output. |
+
+## Recipe Packs
+
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.AI/search` along with the Recipes for every other Resource Type on that platform.
+
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `mcr.microsoft.com/bicep/avm/res/search/search-service:0.12.2` |
+
+## Using the resource type
+
+Add a `search` resource to your application and connect a container to it. Radius injects the search service's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_SEARCH_ENDPOINT` and `CONNECTION_SEARCH_APIKEY`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/AI/search/search.yaml
+++ b/AI/search/search.yaml
@@ -1,0 +1,70 @@
+# Portability note: this schema is platform-neutral so the same Radius.AI/search
+# type can work with Azure AVM (Bicep), AWS Terraform registry modules, and Kubernetes
+# recipes. Only the recipePack source plus parameters/outputs mapping change per platform;
+# the developer-facing properties and readOnly connection surface stay identical.
+namespace: Radius.AI
+types:
+  search:
+    description: |
+      The Radius.AI/search Resource Type deploys a search service. To
+      deploy a search service, add a search resource to the application
+      definition Bicep file. The platform-engineer recipe provisions the concrete
+      backend and maps its endpoint and API key outputs back onto this resource.
+      ```
+      resource search 'Radius.AI/search@2025-08-01-preview' = {
+        name: 'search'
+        properties: {
+          environment: environment
+          application: myApplication.id
+        }
+      }
+      ```
+
+      To connect your container to the service, create a connection from the
+      Container resource to the search service as shown below.
+      ```
+      resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'frontend'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          container: {
+            image: 'frontend:1.25'
+          }
+          connections: {
+            search: {
+              source: search.id
+            }
+          }
+        }
+      }
+      ```
+
+      The connection automatically injects environment variables into the
+      container for all properties from the search service. The environment
+      variables are named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this
+      example the connection name is `search` so the environment variables will be:
+
+      - CONNECTION_SEARCH_ENDPOINT
+      - CONNECTION_SEARCH_APIKEY
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
+            application:
+              type: string
+              description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            endpoint:
+              type: string
+              description: The endpoint used to connect to the search service. Mapped from the recipe module's output.
+              readOnly: true
+            apiKey:
+              type: string
+              description: The admin API key used to connect to the search service. Mapped from the recipe module's output.
+              readOnly: true
+          required: [environment]

--- a/AI/search/test/app.bicep
+++ b/AI/search/test/app.bicep
@@ -1,0 +1,44 @@
+extension radius
+
+extension search
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'search-azure-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource searchService 'Radius.AI/search@2025-08-01-preview' = {
+  name: 'search'
+  properties: {
+    environment: environment
+    application: app.id
+  }
+}
+
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      demo: {
+        image: 'ghcr.io/radius-project/samples/demo:latest'
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      search: {
+        source: searchService.id
+      }
+    }
+  }
+}

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -1,0 +1,41 @@
+# Azure Recipe Pack
+
+This folder contains the **Azure Recipe Pack** — a collection of Recipes that provision Radius Resource Types on Azure, bundled with an Environment definition. Deploying the pack configures a Radius Environment to use the Azure provider and registers the Recipes for every Resource Type it covers.
+
+| File | Description |
+| --- | --- |
+| `bicep-recipepack.bicep` | Recipe Pack wiring the Bicep recipes for all Azure-provisioned types, plus the Environment definition. |
+
+Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, and a `Radius.Core/environments` resource that references the pack and configures the Azure provider.
+
+## Recipes in this pack
+
+| Resource Type | Kind | Source |
+| --- | --- | --- |
+| `Radius.AI/search` | Bicep | Azure Verified Module — `avm/res/search/search-service` |
+| `Radius.Compute/containers` | Bicep | `ghcr.io/radius-project/kube-recipes/containers` |
+
+## Parameters
+
+The Azure pack accepts the provider configuration it needs to provision into your subscription:
+
+| Parameter | Description |
+| --- | --- |
+| `azureSubscriptionId` | Azure subscription ID the Environment provisions resources into. |
+| `azureResourceGroup` | Existing Azure resource group the Environment provisions resources into. |
+
+## Deploying
+
+Deploy the pack with the `rad` CLI, supplying the parameters it requires. Deploying the file creates the `Radius.Core/recipePacks` resource and configures the `default` Environment to use it:
+
+```bash
+rad deploy recipepack/azure/bicep-recipepack.bicep \
+  --parameters azureSubscriptionId=<subscription-id> \
+  --parameters azureResourceGroup=<resource-group>
+```
+
+After the pack is deployed, every Resource Type it covers can be used in an application deployed to that Environment.
+
+## Contributing a Recipe
+
+To add a Recipe for another Resource Type to this pack, add an entry to the `recipes` map keyed by the Resource Type (for example `Radius.AI/search`). For guidance on writing Recipes and wiring them into a Recipe Pack, see [Contributing Resource Types and Radius Recipes](../../docs/contributing/contributing-resource-types-recipes.md#recipes-and-recipe-packs).

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -1,0 +1,88 @@
+// Platform-engineer baseline for verifying Radius.AI/search on Azure via a
+// STANDARD Azure Verified Module (AVM) — no Radius wrapping, no `context`
+// parameter, no `result` output. Using the direct-module feature, Radius resolves
+// recipe parameters, deploys the AVM module to the environment's Azure scope, and
+// maps plain module outputs onto the resource properties via the `outputs` field.
+//
+// Portability: the Radius.AI/search schema is intentionally
+// platform-neutral. An AWS recipe could target a Terraform AWS OpenSearch module
+// and map `endpoint` from the domain endpoint output; a Kubernetes recipe could
+// target an Elasticsearch recipe and map `endpoint` from the service DNS plus
+// `apiKey` from a generated secret. Only recipePack `source`, `parameters`, and
+// `outputs` change while the developer-facing resource stays the same.
+//
+// NOTE: This Azure recipe has an API-compatibility caveat. Elasticsearch/OpenSearch
+// and Azure AI Search do not share the same query API, so a portable application
+// must target a common abstraction or use platform-specific client logic.
+//
+// The AVM version is pinned with the standard Bicep/OCI `:<tag>` syntax.
+
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'search-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.AI/search': {
+        kind: 'bicep'
+        // Standard Azure Verified Module, version pinned with `:<tag>`
+        // (https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/search/search-service).
+        source: 'mcr.microsoft.com/bicep/avm/res/search/search-service:0.12.2'
+        parameters: {
+          name: '{{context.resource.name}}'
+          sku: 'basic'
+          disableLocalAuth: false
+          replicaCount: 1
+          partitionCount: 1
+          // AVM modules emit a Microsoft.Resources/deployments telemetry resource
+          // the Radius Bicep deployment engine can't process at location "global".
+          // Disabling telemetry skips it — the AVM-sanctioned opt-out.
+          enableTelemetry: false
+        }
+        // Map the module's outputs onto the resource's properties.
+        // Keys are resource property names; values are module output names.
+        // The endpoint comes from the AVM `endpoint` output and apiKey comes from
+        // the secure AVM `primaryKey` output, which calls listAdminKeys().primaryKey
+        // when disableLocalAuth is false.
+        outputs: {
+          endpoint: 'endpoint'
+          apiKey: 'primaryKey'
+        }
+      }
+      // Radius.Compute/containers is a default type but needs a recipe to deploy.
+      // The published Kubernetes container recipe materializes the hurl client (which
+      // drives an Azure AI Search REST round-trip) as a Kubernetes Deployment and wires
+      // the `connections` to the search resource.
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'default'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+      // The Radius.Compute/containers recipe provisions a Kubernetes Deployment in
+      // providers.kubernetes.namespace; `default` always exists in the kind cluster.
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds the `Radius.AI/search` resource type and an Azure Recipe Pack via the Azure Verified Module search-service direct module. The source recipe was validated E2E in `resource-types-verification`.

### Resource type

- Adds `Radius.AI/search` under `AI/search`.
- Defines the platform-neutral developer surface for search services.
- Exposes read-only connection outputs for `endpoint` and `apiKey`.

### Recipe Packs

- Adds `recipepack/azure/bicep-recipepack.bicep` using the AVM search-service direct module.
- Registers `Radius.AI/search` and `Radius.Compute/containers` in the Azure Recipe Pack.
- Includes Azure Recipe Pack documentation.

## Type of change

- New resource type
- New Recipe Pack
- Documentation

## Notes

Follows #199 minus the root-docs revamp. `recipepack/azure` overlaps #199/#200; whichever PR merges second should only need a trivial merge.
