### PR TITLE
Add sqlServerDatabases Azure Recipe Pack and adopt the Recipe Pack model

### DIFF
--- a/Data/sqlServerDatabases/README.md
+++ b/Data/sqlServerDatabases/README.md
@@ -1,0 +1,31 @@
+# Radius.Data/sqlServerDatabases
+
+## Overview
+
+The **Radius.Data/sqlServerDatabases** resource type represents a SQL Server database. It allows developers to create and easily connect to a SQL Server database as part of their Radius applications. The developer provides the administrator `username` and `password` directly on the resource; the `password` property is marked `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and injects it decrypted only into the platform's Recipe.
+
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.Data/sqlServerDatabases` command.
+
+## Properties
+
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `database` | string | Required | The SQL database name to create on the server. Defaults to `appdb`. |
+| `username` | string | Required | The administrator username for the SQL database. Passed to the Recipe as `{{context.resource.properties.username}}`. |
+| `password` | string (`x-radius-sensitive`) | Required | The administrator password. Encrypted at rest, redacted on reads, and injected decrypted into the Recipe as `{{context.resource.properties.password}}`. |
+| `host` | string | Read only | The SQL Server fully qualified domain name. Set from the Recipe module's output. |
+| `port` | string | Read only | The SQL Server TCP port. Azure SQL Database listens on 1433. |
+
+## Recipe Packs
+
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.Data/sqlServerDatabases` along with the Recipes for every other Resource Type on that platform.
+
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4` |
+
+## Using the resource type
+
+Add a `sqlServerDatabases` resource to your application and connect a container to it. Radius injects the database's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_SQL_HOST`, `CONNECTION_SQL_PORT`, and `CONNECTION_SQL_DATABASE`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Data/sqlServerDatabases/sqlServerDatabases.yaml
+++ b/Data/sqlServerDatabases/sqlServerDatabases.yaml
@@ -1,0 +1,90 @@
+namespace: Radius.Data
+types:
+  sqlServerDatabases:
+    description: |
+      The Radius.Data/sqlServerDatabases Resource Type deploys a SQL database. Provide the administrator `username` and `password` directly on the resource. The `password` property is marked `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and exposes it (decrypted) only to the recipe that provisions the database.
+      ```
+      resource sqlserver 'Radius.Data/sqlServerDatabases@2025-08-01-preview' = {
+        name: 'sqlserver'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          database: 'appdb'
+          username: 'myadmin'
+          // From a @secure() password parameter passed in via the CLI
+          password: password
+        }
+      }
+      ```
+
+      When deploying the application definition, provide the database password value as a parameter. It is recommended to use a password generator such as `openssl` or equivalent. For example, `rad deploy app.bicep -p password=$(openssl rand -hex 16)`.
+
+      To connect your container to the database, create a connection from the
+      Container resource to the database as shown below. This verification test is
+      provisioning-only because the stock demo image has no SQL Server backend, but
+      the type still exposes a connection surface for applications that can use it.
+      ```
+      resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'frontend'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          container: {
+            image: 'frontend:1.25'
+          }
+          connections: {
+            sqlserver: {
+              source: sqlserver.id
+            }
+          }
+        }
+      }
+      ```
+
+      The connection automatically injects environment variables into the
+      container for all properties from the database. The environment variables are
+      named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example the
+      connection name is `sqlserver` so the environment variables will be:
+
+      - CONNECTION_SQLSERVER_DATABASE
+      - CONNECTION_SQLSERVER_HOST
+      - CONNECTION_SQLSERVER_PORT
+
+      The schema is platform-neutral: the same developer-facing properties can be
+      backed by Azure SQL Database, AWS RDS for SQL Server, or a Kubernetes SQL
+      Server recipe by changing only the platform recipe's module source,
+      parameters, and outputs. Azure maps host from the AVM
+      `fullyQualifiedDomainName` output; AWS Terraform would map an RDS endpoint;
+      Kubernetes would map a Service DNS name.
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
+            application:
+              type: string
+              description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            database:
+              type: string
+              default: appdb
+              description: "(Required) The SQL database name to create on the server. Defaults to `appdb` in the sample application."
+            username:
+              type: string
+              description: "(Required) The administrator username for the SQL database. Provided directly on the resource and passed to the recipe as `{{context.resource.properties.username}}`."
+            password:
+              type: string
+              x-radius-sensitive: true
+              description: "(Required) The administrator password for the SQL database. Marked `x-radius-sensitive`: Radius encrypts it at rest, redacts it on reads, and exposes it decrypted only to the recipe as `{{context.resource.properties.password}}`."
+            host:
+              type: string
+              description: The SQL Server fully qualified domain name. Mapped from the recipe module's `fullyQualifiedDomainName` output.
+              readOnly: true
+            port:
+              type: string
+              description: The SQL Server TCP port. Azure SQL Database listens on 1433.
+              readOnly: true
+          required: [environment, database, username, password]

--- a/Data/sqlServerDatabases/test/app.bicep
+++ b/Data/sqlServerDatabases/test/app.bicep
@@ -1,0 +1,55 @@
+extension radius
+
+extension sqlServerDatabases
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+@description('Database username.')
+@secure()
+param dbUsername string
+
+@description('Database password.')
+@secure()
+param dbPassword string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'sqlserver-azure-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource sqlserver 'Radius.Data/sqlServerDatabases@2025-08-01-preview' = {
+  name: 'sqlserver'
+  properties: {
+    environment: environment
+    application: app.id
+    database: 'appdb'
+    username: dbUsername
+    password: dbPassword
+  }
+}
+
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      demo: {
+        image: 'ghcr.io/radius-project/samples/demo:latest'
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      sql: {
+        source: sqlserver.id
+      }
+    }
+  }
+}

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -1,0 +1,41 @@
+# Azure Recipe Pack
+
+This folder contains the **Azure Recipe Pack** — a collection of Recipes that provision Radius Resource Types on Azure, bundled with an Environment definition. Deploying the pack configures a Radius Environment to use the Azure provider and registers the Recipes for every Resource Type it covers.
+
+| File | Description |
+| --- | --- |
+| `bicep-recipepack.bicep` | Recipe Pack wiring the Bicep recipes for all Azure-provisioned types, plus the Environment definition. |
+
+Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, and a `Radius.Core/environments` resource that references the pack and configures the Azure provider.
+
+## Recipes in this pack
+
+| Resource Type | Kind | Source |
+| --- | --- | --- |
+| `Radius.Data/sqlServerDatabases` | Bicep | Azure Verified Module — `mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4` |
+| `Radius.Compute/containers` | Bicep | `ghcr.io/radius-project/kube-recipes/containers` |
+
+## Parameters
+
+The Azure pack accepts the provider configuration it needs to provision into your subscription:
+
+| Parameter | Description |
+| --- | --- |
+| `azureSubscriptionId` | Azure subscription ID the Environment provisions resources into. |
+| `azureResourceGroup` | Existing Azure resource group the Environment provisions resources into. |
+
+## Deploying
+
+Deploy the pack with the `rad` CLI, supplying the parameters it requires. Deploying the file creates the `Radius.Core/recipePacks` resource and configures the `default` Environment to use it:
+
+```bash
+rad deploy recipepack/azure/bicep-recipepack.bicep \
+  --parameters azureSubscriptionId=<subscription-id> \
+  --parameters azureResourceGroup=<resource-group>
+```
+
+After the pack is deployed, every Resource Type it covers can be used in an application deployed to that Environment.
+
+## Contributing a Recipe
+
+To add a Recipe for another Resource Type to this pack, add an entry to the `recipes` map keyed by the Resource Type (for example `Radius.Data/sqlServerDatabases`). For guidance on writing Recipes and wiring them into a Recipe Pack, see [Contributing Resource Types and Radius Recipes](../../docs/contributing/contributing-resource-types-recipes.md#recipes-and-recipe-packs).

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -1,0 +1,96 @@
+// Platform-engineer baseline for verifying Radius.Data/sqlServerDatabases on Azure via
+// a STANDARD Azure Verified Module (AVM) — no Radius wrapper recipe. Radius
+// resolves {{context.*}} expressions in `parameters`, runs the AVM through the
+// Bicep driver + deployment engine, and maps plain module outputs onto resource
+// properties via `outputs`.
+//
+// Credentials: the developer authors the administrator `username` and `password`
+// directly on the sqlServerDatabases resource (app.bicep). `password` is marked
+// `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and
+// exposes it decrypted only to this recipe as
+// {{context.resource.properties.username/password}}, wired onto the AVM's
+// administratorLogin/administratorLoginPassword below.
+//
+// Portability: this schema is platform-neutral. For AWS RDS SQL Server, a
+// Terraform recipe would map `host` from the DB instance endpoint/address and pass
+// the same username/password through. For Kubernetes, a recipe could deploy an mssql
+// container or StatefulSet, expose it with a Service DNS name for `host`, and set
+// `port` to 1433.
+
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'sqlserver-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/sqlServerDatabases': {
+        kind: 'bicep'
+        // Standard Azure Verified Module, version pinned with `:<tag>`
+        // (https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/sql/server).
+        source: 'mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4'
+        parameters: {
+          name: '{{context.resource.name}}'
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+          publicNetworkAccess: 'Enabled'
+          firewallRules: [
+            {
+              name: 'AllowAllWindowsAzureIps'
+              startIpAddress: '0.0.0.0'
+              endIpAddress: '0.0.0.0'
+            }
+          ]
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+              availabilityZone: -1
+              sku: {
+                name: 'Basic'
+                tier: 'Basic'
+              }
+              maxSizeBytes: 2147483648
+              zoneRedundant: false
+            }
+          ]
+          enableTelemetry: false
+        }
+        // Map the module's FQDN output onto the resource's `host` property. The
+        // AVM has no port output; Azure SQL Database uses the fixed TCP port 1433.
+        outputs: {
+          host: 'fullyQualifiedDomainName'
+        }
+      }
+      // Radius.Compute/containers is a default type but needs a recipe to deploy.
+      // The published Kubernetes container recipe materializes the golang-migrate
+      // client (which connects to the Azure SQL database) as a Kubernetes Deployment.
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'default'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds `Radius.Data/sqlServerDatabases` and an Azure Recipe Pack entry that provisions SQL Server through the Azure Verified Module direct module (`avm/res/sql/server`). The resource type and Recipe Pack were validated E2E in `resource-types-verification`.

### Resource type

- Adds `Data/sqlServerDatabases/sqlServerDatabases.yaml` using the validated `Radius.Data/sqlServerDatabases` schema.
- Documents developer-authored `username`, `password` (`x-radius-sensitive`), and `database` properties, plus read-only connection outputs.
- Adds a test application that sets `dbUsername` and `dbPassword` as secure params and connects a demo container to the SQL Server resource.

### Recipe Packs

- Adds `recipepack/azure/bicep-recipepack.bicep` with the `sqlserver-azure-avm` Recipe Pack.
- Registers `Radius.Data/sqlServerDatabases` with the AVM SQL server direct module and `Radius.Compute/containers` with the public Kubernetes containers recipe.
- Configures the default Environment for Azure and Kubernetes providers.

## Type of change

- New resource type
- New Recipe Pack
- Documentation

## Notes

- Follows #199 minus the root-docs revamp.
- `recipepack/azure` overlaps #199/#200; the second merged PR will need a trivial merge.
