### PR TITLE
update test workflow

### DIFF
--- a/.github/scripts/build-resource-type.sh
+++ b/.github/scripts/build-resource-type.sh
@@ -38,6 +38,36 @@ validate_dependencies() {
     fi
 }
 
+# Derive the "Radius.<Category>/<typeName>" identifier for a resource type folder
+# from its path, following the resource-types-contrib layout convention
+# (<Category>/<typeName>/<typeName>.yaml).
+resource_type_id_for_folder() {
+    local folder="$1"
+    local rel="${folder#"$REPO_ROOT"/}"
+    local category type_name
+    category="$(printf '%s' "$rel" | cut -d/ -f1)"
+    type_name="$(printf '%s' "$rel" | cut -d/ -f2)"
+    printf 'Radius.%s/%s' "$category" "$type_name"
+}
+
+# Return 0 if the given "Radius.<Category>/<typeName>" identifier is one of the
+# resource types that ship as Radius defaults (see defaults.yaml). Default types
+# are already registered by Radius and their Bicep types are bundled in the
+# "radius" extension, so the test workflow skips creating/publishing them.
+is_default_resource_type() {
+    local resource_type_id="$1"
+    local default_type
+
+    while IFS= read -r default_type; do
+        [[ -z "$default_type" ]] && continue
+        if [[ "$default_type" == "$resource_type_id" ]]; then
+            return 0
+        fi
+    done < <("${SCRIPT_DIR}/list-default-resource-types.sh")
+
+    return 1
+}
+
 create_resource_type() {
     local yaml_file="$1"
 
@@ -83,6 +113,14 @@ main() {
     fi
 
     target_folder="$(cd "$target_folder" && pwd)"
+
+    local resource_type_id
+    resource_type_id="$(resource_type_id_for_folder "$target_folder")"
+
+    if is_default_resource_type "$resource_type_id"; then
+        echo "⏭️  Skipping '$resource_type_id': ships as a Radius default (defaults.yaml); it is already registered and bundled in the 'radius' extension. Not creating the resource type or publishing an extension."
+        exit 0
+    fi
 
     local -a yaml_files=()
     mapfile -d '' -t yaml_files < <(find "$target_folder" -maxdepth 1 -mindepth 1 -type f \

--- a/.github/scripts/list-default-resource-types.sh
+++ b/.github/scripts/list-default-resource-types.sh
@@ -33,16 +33,35 @@
 # Configuration (environment variables):
 #   DEFAULT_RESOURCE_TYPES  Space/newline separated list that overrides the
 #                           fetched list entirely (useful for offline/testing).
-#   DEFAULTS_YAML_URL       Override the source URL for defaults.yaml.
+#   RADIUS_VERSION          Radius version under test (e.g. "0.58.0", "v0.58.0",
+#                           or "edge"). Selects the matching defaults.yaml so the
+#                           skip list matches the defaults the installed Radius
+#                           actually registers. "edge" or empty maps to "main".
+#   DEFAULTS_YAML_URL       Override the source URL for defaults.yaml entirely.
 #
 # On network failure with no cache available, prints nothing and exits 0 so that
-# callers fall back to the previous behavior (build/publish everything).
+# callers fall back to the previous behavior (build/publish everything). This is
+# also the correct behavior for Radius versions predating defaults.yaml (before
+# ~v0.58.0), where the file does not exist and no types ship as defaults.
 # =============================================================================
 
 set -euo pipefail
 
-DEFAULTS_YAML_URL="${DEFAULTS_YAML_URL:-https://raw.githubusercontent.com/radius-project/radius/main/deploy/manifest/defaults.yaml}"
-CACHE_FILE="${TMPDIR:-/tmp}/radius-default-resource-types.cache"
+# Resolve the git ref for defaults.yaml from the Radius version under test.
+# Release tags are three-part (vX.Y.Z); "edge"/empty tracks the main branch.
+RADIUS_VERSION="${RADIUS_VERSION:-}"
+DEFAULTS_REF="main"
+if [[ -n "$RADIUS_VERSION" && "$RADIUS_VERSION" != "edge" ]]; then
+    DEFAULTS_REF="$RADIUS_VERSION"
+    [[ "$DEFAULTS_REF" == v* ]] || DEFAULTS_REF="v$DEFAULTS_REF"
+fi
+
+DEFAULTS_YAML_URL="${DEFAULTS_YAML_URL:-https://raw.githubusercontent.com/radius-project/radius/${DEFAULTS_REF}/deploy/manifest/defaults.yaml}"
+
+# Cache per resolved URL so an explicit DEFAULTS_YAML_URL override and the
+# version-derived URL never share a cache entry within the same run.
+CACHE_KEY="$(printf '%s' "$DEFAULTS_YAML_URL" | tr -c 'A-Za-z0-9' '_')"
+CACHE_FILE="${TMPDIR:-/tmp}/radius-default-resource-types.${CACHE_KEY}.cache"
 
 # Explicit override wins and is not cached.
 if [[ -n "${DEFAULT_RESOURCE_TYPES:-}" ]]; then

--- a/.github/scripts/list-default-resource-types.sh
+++ b/.github/scripts/list-default-resource-types.sh
@@ -46,7 +46,8 @@ CACHE_FILE="${TMPDIR:-/tmp}/radius-default-resource-types.cache"
 
 # Explicit override wins and is not cached.
 if [[ -n "${DEFAULT_RESOURCE_TYPES:-}" ]]; then
-    printf '%s\n' $DEFAULT_RESOURCE_TYPES | sed '/^[[:space:]]*$/d'
+    # Split on whitespace while avoiding pathname expansion.
+    printf '%s\n' "$DEFAULT_RESOURCE_TYPES" | tr -s '[:space:]' '\n' | sed '/^[[:space:]]*$/d'
     exit 0
 fi
 

--- a/.github/scripts/list-default-resource-types.sh
+++ b/.github/scripts/list-default-resource-types.sh
@@ -60,7 +60,7 @@ fi
 # form "Radius.<Namespace>/<typeName>", so a targeted grep is sufficient and is
 # resilient to comments or additional sections in the file.
 fetched=""
-if fetched="$(curl -fsSL "$DEFAULTS_YAML_URL" 2>/dev/null)"; then
+if fetched="$(curl -fsSL --connect-timeout 5 --max-time 20 "$DEFAULTS_YAML_URL" 2>/dev/null)"; then
     parsed="$(printf '%s\n' "$fetched" | grep -oE 'Radius\.[A-Za-z0-9]+/[A-Za-z0-9]+' | sort -u || true)"
     if [[ -n "$parsed" ]]; then
         printf '%s\n' "$parsed" > "$CACHE_FILE"

--- a/.github/scripts/list-default-resource-types.sh
+++ b/.github/scripts/list-default-resource-types.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# ------------------------------------------------------------
+# Copyright 2025 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# =============================================================================
+# list-default-resource-types.sh
+# -----------------------------------------------------------------------------
+# Print the resource types that ship as defaults in Radius, one per line, in the
+# "<namespace>/<typeName>" format (e.g. "Radius.Data/mySqlDatabases").
+#
+# These types are already registered by a stock Radius install and their Bicep
+# types are bundled in the unified "radius" extension, so the test workflow does
+# not need to create them or publish a standalone extension for them.
+#
+# The list is sourced from the Radius repo's deploy/manifest/defaults.yaml
+# (defaultRegistration entries). The result is cached for the lifetime of the
+# CI run so repeated invocations do not re-download the file.
+#
+# Configuration (environment variables):
+#   DEFAULT_RESOURCE_TYPES  Space/newline separated list that overrides the
+#                           fetched list entirely (useful for offline/testing).
+#   DEFAULTS_YAML_URL       Override the source URL for defaults.yaml.
+#
+# On network failure with no cache available, prints nothing and exits 0 so that
+# callers fall back to the previous behavior (build/publish everything).
+# =============================================================================
+
+set -euo pipefail
+
+DEFAULTS_YAML_URL="${DEFAULTS_YAML_URL:-https://raw.githubusercontent.com/radius-project/radius/main/deploy/manifest/defaults.yaml}"
+CACHE_FILE="${TMPDIR:-/tmp}/radius-default-resource-types.cache"
+
+# Explicit override wins and is not cached.
+if [[ -n "${DEFAULT_RESOURCE_TYPES:-}" ]]; then
+    printf '%s\n' $DEFAULT_RESOURCE_TYPES | sed '/^[[:space:]]*$/d'
+    exit 0
+fi
+
+# Reuse the cached list within the same CI run.
+if [[ -s "$CACHE_FILE" ]]; then
+    cat "$CACHE_FILE"
+    exit 0
+fi
+
+# Fetch and parse the defaultRegistration entries. Every default entry is of the
+# form "Radius.<Namespace>/<typeName>", so a targeted grep is sufficient and is
+# resilient to comments or additional sections in the file.
+fetched=""
+if fetched="$(curl -fsSL "$DEFAULTS_YAML_URL" 2>/dev/null)"; then
+    parsed="$(printf '%s\n' "$fetched" | grep -oE 'Radius\.[A-Za-z0-9]+/[A-Za-z0-9]+' | sort -u || true)"
+    if [[ -n "$parsed" ]]; then
+        printf '%s\n' "$parsed" > "$CACHE_FILE"
+        printf '%s\n' "$parsed"
+        exit 0
+    fi
+    echo "Warning: no defaultRegistration entries found in $DEFAULTS_YAML_URL" >&2
+else
+    echo "Warning: failed to fetch defaults.yaml from $DEFAULTS_YAML_URL; treating no resource types as defaults" >&2
+fi
+
+exit 0

--- a/.github/workflows/validate-azure-recipes.yaml
+++ b/.github/workflows/validate-azure-recipes.yaml
@@ -164,6 +164,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      DEFAULTS_YAML_URL: ${{ (inputs.version && inputs.version != 'edge') && format('https://raw.githubusercontent.com/radius-project/radius/v{0}/deploy/manifest/defaults.yaml', inputs.version) || 'https://raw.githubusercontent.com/radius-project/radius/main/deploy/manifest/defaults.yaml' }}
     steps:
       - name: Set up checkout target
         id: checkout-target

--- a/.github/workflows/validate-resource-types.yaml
+++ b/.github/workflows/validate-resource-types.yaml
@@ -42,6 +42,7 @@ jobs:
       contents: read
     env:
       RAD_ENVIRONMENT_NAME: default
+      DEFAULTS_YAML_URL: ${{ (inputs.version && inputs.version != 'edge') && format('https://raw.githubusercontent.com/radius-project/radius/v{0}/deploy/manifest/defaults.yaml', inputs.version) || 'https://raw.githubusercontent.com/radius-project/radius/main/deploy/manifest/defaults.yaml' }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Description
This PR updates the test workflow to only build extensions that are not by default in the Radius extension 

Related GitHub Issue: <!--#issue_number or N/A-->

## Testing
<!--
Describe how a reviewer should test these changes.
-->

## Contributor Checklist

- [ ] File names follow naming conventions and folder structure
- [ ] Platform engineer documentation is in README.md
- [ ] Developer documentation is the top-level description property
- [ ] Example of defining the Resource Type is in the developer documentation
- [ ] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [ ] All properties in the Resource Type definition have clear descriptions
- [ ] Enum properties have values defined in `enum: []`
- [ ] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [ ] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [ ] Recipes include a results output variable with all read-only properties set
- [ ] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [ ] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [ ] Recipes are provided for at least one platform
- [ ] Recipes handle secrets securely
- [ ] Recipes are idempotent
- [ ] Resource types and recipes were tested
