### PR TITLE
Add Radius.Data/redisCaches resource type and Azure Recipe Pack

### DIFF
--- a/Data/redisCaches/README.md
+++ b/Data/redisCaches/README.md
@@ -1,0 +1,30 @@
+# Radius.Data/redisCaches
+
+## Overview
+
+The **Radius.Data/redisCaches** resource type represents a Redis cache. It allows developers to create and easily connect to a Redis cache as part of their Radius applications. Unlike database types, no secret is required — the platform's Recipe provisions a cache that generates its own access keys, so no credentials need to be injected.
+
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.Data/redisCaches` command.
+
+## Properties
+
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `size` | string (`S`, `M`, `L`) | Optional | The size of the Redis cache. Defaults to `S`. The Recipe maps the size onto a concrete cloud SKU. |
+| `host` | string | Read only | The host name used to connect to the cache. Set from the Recipe module's output. |
+| `port` | integer | Read only | The TLS port number used to connect to the cache. Set from the Recipe module's output. |
+| `url` | string (sensitive) | Read only | The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`), including the access key. Set from the Recipe module's output and treated as a secret. |
+
+## Recipe Packs
+
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.Data/redisCaches` along with the Recipes for every other Resource Type on that platform.
+
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `avm/res/cache/redis-enterprise` |
+
+## Using the resource type
+
+Add a `redisCaches` resource to your application and connect a container to it. Radius injects the cache's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_REDIS_HOST`, `CONNECTION_REDIS_PORT`, and `CONNECTION_REDIS_URL`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Data/redisCaches/README.md
+++ b/Data/redisCaches/README.md
@@ -15,7 +15,7 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `size` | string (`S`, `M`, `L`) | Optional | The size of the Redis cache. Defaults to `S`. The Recipe maps the size onto a concrete cloud SKU. |
 | `host` | string | Read only | The host name used to connect to the cache. Set from the Recipe module's output. |
 | `port` | integer | Read only | The TLS port number used to connect to the cache. Set from the Recipe module's output. |
-| `url` | string (sensitive) | Read only | The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`), including the access key. Set from the Recipe module's output and treated as a secret. |
+| `url` | string | Read only | The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`), including the access key. Set from the Recipe module's output. |
 
 ## Recipe Packs
 

--- a/Data/redisCaches/redisCaches.yaml
+++ b/Data/redisCaches/redisCaches.yaml
@@ -26,8 +26,10 @@ types:
         properties: {
           application: myApplication.id
           environment: environment
-          container: {
-            image: 'frontend:1.25'
+          containers: {
+            frontend: {
+              image: 'frontend:1.25'
+            }
           }
           connections: {
             redis: {
@@ -64,14 +66,15 @@ types:
               description: "(Optional) The size of the Redis cache. Defaults to `S` if not provided. The recipe maps the size onto a concrete cloud SKU."
             host:
               type: string
-              description: The host name used to connect to the cache. Mapped from the recipe module's output.
+              description: "(Read Only) The host name used to connect to the cache. Mapped from the recipe module's output."
               readOnly: true
             port:
               type: integer
-              description: The TLS port number used to connect to the cache. Mapped from the recipe module's `port` output (Azure Managed Redis uses 10000).
+              description: "(Read Only) The TLS port number used to connect to the cache. Mapped from the recipe module's `port` output (Azure Managed Redis uses 10000)."
               readOnly: true
             url:
               type: string
-              description: The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output.
+              description: "(Read Only) The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output."
+              x-radius-sensitive: true
               readOnly: true
           required: [environment]

--- a/Data/redisCaches/redisCaches.yaml
+++ b/Data/redisCaches/redisCaches.yaml
@@ -1,0 +1,77 @@
+namespace: Radius.Data
+types:
+  redisCaches:
+    description: |
+      The Radius.Data/redisCaches Resource Type deploys a Redis cache. To deploy a
+      Redis cache, add a redisCaches resource to the application definition Bicep
+      file. Unlike database types, no secret is required: Azure Managed Redis
+      generates its own access keys, so the platform-engineer recipe needs no
+      injected credentials.
+      ```
+      resource cache 'Radius.Data/redisCaches@2025-08-01-preview' = {
+        name: 'redis'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          size: 'S'
+        }
+      }
+      ```
+
+      To connect your container to the cache, create a connection from the
+      Container resource to the cache as shown below.
+      ```
+      resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'frontend'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          container: {
+            image: 'frontend:1.25'
+          }
+          connections: {
+            redis: {
+              source: cache.id
+            }
+          }
+        }
+      }
+      ```
+
+      The connection automatically injects environment variables into the
+      container for all properties from the cache. The environment variables are
+      named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example the
+      connection name is `redis` so the environment variables will be:
+
+      - CONNECTION_REDIS_HOST
+      - CONNECTION_REDIS_PORT
+      - CONNECTION_REDIS_URL
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
+            application:
+              type: string
+              description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            size:
+              type: string
+              enum: ['S', 'M', 'L']
+              description: "(Optional) The size of the Redis cache. Defaults to `S` if not provided. The recipe maps the size onto a concrete cloud SKU."
+            host:
+              type: string
+              description: The host name used to connect to the cache. Mapped from the recipe module's output.
+              readOnly: true
+            port:
+              type: integer
+              description: The TLS port number used to connect to the cache. Mapped from the recipe module's `port` output (Azure Managed Redis uses 10000).
+              readOnly: true
+            url:
+              type: string
+              description: The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output. Marked sensitive so Radius treats it as a secret.
+              readOnly: true
+          required: [environment]

--- a/Data/redisCaches/redisCaches.yaml
+++ b/Data/redisCaches/redisCaches.yaml
@@ -72,6 +72,6 @@ types:
               readOnly: true
             url:
               type: string
-              description: The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output. Marked sensitive so Radius treats it as a secret.
+              description: The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output.
               readOnly: true
           required: [environment]

--- a/Data/redisCaches/test/app.bicep
+++ b/Data/redisCaches/test/app.bicep
@@ -1,0 +1,45 @@
+extension radius
+
+extension redisCaches
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'redis-azure-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource redis 'Radius.Data/redisCaches@2025-08-01-preview' = {
+  name: 'redis'
+  properties: {
+    environment: environment
+    application: app.id
+    size: 'S'
+  }
+}
+
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      demo: {
+        image: 'ghcr.io/radius-project/samples/demo:latest'
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      redis: {
+        source: redis.id
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 This repository contains the Resource Type definitions and Recipes for deploying those Resource Types via [Radius](https://radapp.io/). It includes:
 
 - **Resource Type Defintions**: Schema definitions for Resource Types available for developers to use while defining their application
-- **Recipes**: Platform-specific Infrastructure as Code used to deploy the associated Resource Type
-- **Recipe Packs**: Bundled collections of Recipes organized compute platform or deployment scenario (coming soon)
+- **Recipe Packs**: Bundled collections of Recipes, grouped by compute platform, that provide the recipe definitions for every Resource Type in the repository
 
 ## What are Resource Types?
 
@@ -14,11 +13,11 @@ Resource Types are abstractions that define the schema for resources in the Radi
 
 ## What are Recipes?
 
-Recipes define how the Resource Types are provisioned on different compute platforms and cloud environments. Recipes provide the implementation of the interface defined in the Resource Type definition. To learn more about Recipes, please visit [Recipes overview](https://docs.radapp.io/guides/recipes/overview/) in the Radius documentation.
+Recipes define how the Resource Types are provisioned on different compute platforms and cloud environments. A Recipe provides the implementation of the interface defined in the Resource Type definition. Today Radius supports Bicep and Terraform Recipe drivers, so a Recipe can be a Bicep template or a Terraform configuration. It can also point to well-maintained community modules like the [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) or the [AWS Terraform modules](https://registry.terraform.io/namespaces/terraform-aws-modules). To learn more about Recipes, please visit [Recipes overview](https://docs.radapp.io/guides/recipes/overview/) in the Radius documentation.
 
 ## What are Recipe Packs?
 
-Recipe Packs are collections of Recipes that are grouped together to provide a complete solution for a specific compute platform or deployment scenario. Recipe Packs enable platform engineers to easily add an entire collection of Recipes to a Radius Environment. The Recipe Packs feature is currently under development.
+Recipe Packs are collections of Recipes grouped together to provide a complete solution for a specific compute platform. Platform engineers add an entire collection of Recipes to a Radius Environment by referencing a single Recipe Pack, rather than registering Recipes one Resource Type at a time.
 
 ## Repository Structure
 
@@ -27,52 +26,38 @@ resource-types-contrib/
 ├── <resource_type_namespace>/          # Namespace excluding Radius; the namespace Radius.Data is in the Data directory
 │   └── <resource_type_name>/           # e.g., redisCaches/
 │       ├── README.md                   # Documentation for platform engineers
-│       ├── <resource_type_name>.yaml/  # e.g., redisCaches.yaml
-│       └── recipes/                    # Recipes for this type
-│               ├── <platform-service>  # e.g., aws-memorydb/
-│               │       ├── bicep
-│               │       │       ├── aws-memorydb.bicep
-│               │       │       └── aws-memorydb.params
-│               │       └── terraform
-│               │               ├── main.tf
-│               │               └── var.tf
-│               ├── <platform-service>  # e.g., azure-cache/
-│               │       ├── bicep
-│               │       │       ├── azure-cache.bicep
-│               │       │       └── azure-cache.params
-│               │       └── terraform
-│               │               ├── main.tf
-│               │               └── var.tf
-│               └── <platform-service>  # e.g., kubernetes/
-│                       ├── bicep
-│                       │       ├── kubernetes-redis.bicep
-│                       │       └── kubernetes-redis.params
-│                       └── terraform
-│                               ├── main.tf
-│                               └── var.tf
-└── recipe-packs/
-    ├── azure-aci/                      # Azure Container Instances Recipes
-    ├── kubernetes/                     # Kubernetes platform Recipes
-    └── ...
+│       ├── <resource_type_name>.yaml   # e.g., redisCaches.yaml
+│       └── test/
+│               └── app.bicep           # Developer-facing test application
+└── recipepack/                         # Recipe packs cover recipe definitions for all types in the repo
+    ├── azure/                           # Azure recipe packs (recipes for all types + environment)
+    │       ├── README.md                    # Documentation for the Azure recipe packs
+    │       ├── bicep-recipepack.bicep       # Recipe pack wiring Bicep recipes
+    │       └── terraform-recipepack.bicep   # Recipe pack wiring Terraform recipes
+    ├── aws/                             # AWS recipe packs
+    │       ├── README.md
+    │       └── terraform-recipepack.bicep   # AWS recipes use Terraform modules
+    ├── kubernetes/                      # Kubernetes recipe packs
+    │       ├── README.md
+    │       ├── bicep-recipepack.bicep
+    │       └── terraform-recipepack.bicep
+    └── default-kubernetes/              # Default recipe pack 
+            ├── README.md
+            ├── bicep-recipepack.bicep
+            └── terraform-recipepack.bicep
 ```
 
-## Default resource types in Radius
+## Discovering and using Resource Types and Recipe Packs
 
-Resource types in this repository are available for users to register via `rad resource-type create`. A subset of these are also registered as defaults in Radius, meaning they are available out of the box without any user action.
+Developers can discover the Resource Types in this repository and use them in a Radius application, and platform engineers can use the Recipe Packs to configure how those types are provisioned in an Environment. For a step-by-step guide on discovering, registering, and using Resource Types and Recipe Packs, see [Discovering and Using Resource Types and Recipe Packs](docs/using-resource-types.md).
 
-The list of default resource types is managed in the [Radius repository](https://github.com/radius-project/radius) via `deploy/manifest/defaults.yaml`. To make a resource type a default:
-
-1. Add the resource type manifest to this repository and merge the PR.
-2. In the Radius repository, add the resource type to `deploy/manifest/defaults.yaml`, run `make update-resource-types`, and create a PR. Once this PR is merged, the type is available and the Bicep extension is published.
-
-For more details, see the [defaults.yaml](https://github.com/radius-project/radius/blob/main/deploy/manifest/defaults.yaml) file in the Radius repository.
+Every Resource Type in this repository can be registered via `rad resource-type create`. A subset is also registered as defaults in Radius, so they are available out of the box without any user action. The default resource types are paired with the default Recipe Pack under `recipepack/default-kubernetes/`, a zero-config, in-cluster Kubernetes pack that ships out of the box, so they can be deployed without any cloud provider configuration. The list of default resource types is managed in the [Radius repository](https://github.com/radius-project/radius) via [`deploy/manifest/defaults.yaml`](https://github.com/radius-project/radius/blob/main/deploy/manifest/defaults.yaml).
 
 ## Contributing
 
 Community members can contribute new Resource Types, Recipes, and Recipe Packs to this repository. We welcome contributions in many forms: submitting issues, writing code, participating in discussions, reviewing pull requests. For information on contributing, follow these guides:
 
-- [Contributing Resource Types and Radius Recipes](docs/contributing/contributing-resource-types-recipes.md): This guide provides an overview of how to write a Resource Type and one or more Recipes.
-- Contributing Recipe Packs: Coming soon!
+- [Contributing Resource Types and Radius Recipes](docs/contributing/contributing-resource-types-recipes.md): This guide provides an overview of how to write a Resource Type and its Recipes in a Recipe Pack.
 - [Submitting Issues](docs/contributing/contributing-issues.md): This guide provides an overview of how to submit issues related to Resource Types or Recipes.
 
 **Thanks to everyone who has contributed!**

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 This repository contains the Resource Type definitions and Recipes for deploying those Resource Types via [Radius](https://radapp.io/). It includes:
 
-- **Resource Type Defintions**: Schema definitions for Resource Types available for developers to use while defining their application
+- **Resource Type Definitions**: Schema definitions for Resource Types available for developers to use while defining their application
+- **Recipes**: Platform-specific Infrastructure as Code (Bicep or Terraform) used to deploy the associated Resource Type
 - **Recipe Packs**: Bundled collections of Recipes, grouped by compute platform, that provide the recipe definitions for every Resource Type in the repository
 
 ## What are Resource Types?

--- a/docs/contributing/contributing-resource-types-recipes.md
+++ b/docs/contributing/contributing-resource-types-recipes.md
@@ -1,64 +1,23 @@
-# Contributing Resource Type Definitions and Recipes to Radius
+# Contributing Resource Types and Recipes to Radius
 
-This guide walks you through the process of creating and contributing Radius Resource Type definitions and Recipes to this repository.
+This guide walks you through the process of creating and contributing Radius Resource Types and Recipes to this repository.
 
 ## Prerequisites
 
-Before you begin, ensure you have basic understanding of Radius concepts and the IaC languages you plan to use (Bicep or Terraform). 
+Before you begin, ensure you have a basic understanding of Radius concepts and the IaC languages you plan to use (Bicep or Terraform).
 
- - Familiarize yourself with the [Radius](https://docs.radapp.io) 
- - Familiarize yourself with the [Resource Types](https://docs.radapp.io/tutorials/create-resource-type/) tutorial
- - Familiarize yourself with the [Radius Recipes](https://docs.radapp.io/guides/recipes) concept
+- Familiarize yourself with the [Radius](https://docs.radapp.io) 
+- Familiarize yourself with the [Resource Types](https://docs.radapp.io/concepts/resource-types/) and [Radius Recipes](https://docs.radapp.io/concepts/recipes/) concept
 
 ## Overview
 
 Contributing a Resource Type and Recipe involves the following:
 
 1. [**Resource Type Definition**](#resource-type-definition): Defines the structure and properties of your Resource Type
-2. [**Recipes**](#recipes-for-the-resource-type): Terraform or Bicep templates for deploying the Resource on different platforms
+2. [**Recipes and Recipe Packs**](#recipes-and-recipe-packs): The Recipe that deploys the Resource Type, it could be a Recipe written from scratch or an existing module as Recipe added to the platform Recipe Packs
 3. [**Documentation**](#document-your-resource-type-and-recipes): Providing clear usage examples and instructions
 4. [**Testing**](testing-resource-types-recipes.md): Ensuring your Resource Type works as expected in a Radius Environment
 5. [**Submission**](submitting-contribution.md): Creating a pull request with your changes
-
-## Maturity Levels
-
-Radius Resource Types and Recipes are categorized into the three maturity levels detailed below. Contributions of Resource Types and Recipes may begin at the `Alpha` or `Beta` stage and progress through to the `Stable` phase.
-
-_Stage 1: Alpha_
-
-    Purpose: Enable community members to contribute Resource Types and Recipes with minimal barriers
-    Audience: Developers/Contributors exploring new technologies or learning Radius
-    Requirements:
-        - Resource Type schema validation: YAML schema passes validation
-        - Single Recipe: At least one working Recipe for any cloud platform
-        - Basic documentation: README with usage examples
-        - Manual testing: Evidence of local testing by contributor
-        - Maintainer review: Formal review and approval by Radius maintainers
-
-_Stage 2: Beta_
-
-    Purpose: Ensure contributions meet production-ready standards with comprehensive testing and documentation
-    Audience: Contributors seeking to have their Resource Types included in official Radius releases
-    Requirements:
-        - Multi-platform support: Recipes for all three platforms (AWS, Azure, and Kubernetes)
-        - IAC support: Recipes for both Bicep and Terraform
-        - Automated testing: Functional tests that validate the Resource Type and Recipes
-        - Documentation: Detailed README written for platform engineers describing Recipe behavior as well as developer documentation in the description fields of the Resource Type definition
-        - Ownership: Designated owner for the Resource Type and Recipe
-        - Maintainer review: Formal review and approval by Radius maintainers
-
-_Stage 3: Stable_
-
-    Purpose: Establish Resource Types and Recipes as officially supported and maintained by the Radius project
-    Audience: Enterprise users doing production deployments and seeking stable, well-tested Resource Types and Recipes
-    Requirements:
-        - Functional tests have 100% coverage and results for Resource Type definition and Recipes
-        - Integration testing: Full integration with Radius CI/CD pipeline and release process
-        - Documentation: Well proven platform engineer and developer documentation
-        - Ownership (Resource Type and Kubernetes Recipes): Radius maintainers assume ownership of the Resource Type definition and Kubernetes Recipes
-        - Ownership (cloud platform Recipes): Contributor designates a committed owner for the cloud platform Recipes (e.g. AWS and Azure)
-        - SLA commitment: Defined support level and response time commitments from cloud platform Recipe owners
-        - Maintainer review: Formal review and approval by Radius maintainers
 
 ## Resource Type Definition
 
@@ -76,36 +35,32 @@ git clone https://github.com/<your-username>/resource-types-contrib.git
 
 ### 3. Create a new Resource Type directory
 
-Create a new directory for your Resource Type under the appropriate category. For example if you are contributing a new `redisCaches` Resource Type, the directory structure should look like this:
+Create a new directory for your Resource Type under the appropriate category. Your Resource Type directory holds the schema definition, platform-engineer documentation, and a test application. The Recipes that deploy your Resource Type are added to the shared Recipe Packs at the repository root. For example, if you are contributing a new `redisCaches` Resource Type, the layout should look like this:
 
 ```
 resource-types-contrib/
-└── Data/
- └── redisCaches/
-  ├── redisCaches.yaml
-  ├── README.md
-  └── recipes/
-    ├── aws-memorydb/
-    │   ├── bicep/
-    │   │   ├── memorydb.bicep
-    │   │   └── memorydb.params
-    │   └── terraform/
-    │       ├── main.tf
-    │       └── var.tf
-    ├── azure-cache/
-    │   ├── bicep/
-    │   │   ├── azure-cache.bicep
-    │   │   └── azure-cache.params
-    │   └── terraform/
-    │       ├── main.tf
-    │       └── var.tf    
-    └── kubernetes/
-        ├── bicep/
-        │   ├── kubernetes-redis.bicep
-        │   └── kubernetes-redis.params
-        └── terraform/
-            ├── main.tf
-            └── var.tf
+├── Data/
+│   └── redisCaches/
+│       ├── redisCaches.yaml         # Resource Type definition
+│       ├── README.md                # Documentation for platform engineers
+│       └── test/
+│           └── app.bicep            # Developer-facing test application
+└── recipepack/                      # Recipe Packs cover recipes for all types in the repo
+    ├── azure/                        # Azure recipe packs (recipes for all types + environment)
+    │       ├── README.md                  # Documentation for the Azure recipe packs
+    │       ├── bicep-recipepack.bicep     # Recipe pack wiring Bicep recipes
+    │       └── terraform-recipepack.bicep # Recipe pack wiring Terraform recipes
+    ├── aws/                          # AWS recipe packs
+    │       ├── README.md
+    │       └── terraform-recipepack.bicep # AWS recipes use Terraform modules
+    ├── kubernetes/                   # Kubernetes recipe packs
+    │       ├── README.md
+    │       ├── bicep-recipepack.bicep
+    │       └── terraform-recipepack.bicep
+    └── default-kubernetes/           # Default recipe pack (zero-config, in-cluster)
+            ├── README.md
+            ├── bicep-recipepack.bicep
+            └── terraform-recipepack.bicep
 ```
 
 ### 4. Define Your Resource Type Definition
@@ -156,7 +111,7 @@ The following guidelines should be followed when contributing new Resource Types
 
 - The Resource Type name follows the camelCase convention and is in plural form, such as `redisCaches`, `sqlDatabases`, or `rabbitMQQueues`.
 
-- Version should be the latest date and follow the format `YYYY-MM-DD-preview`. This is the date on which the contribution is made or when the Resource Type is tested and validated, e.g. `2025-07-20-preview`. Once the Resource Types has reached the Stable maturity level, the `-preview` suffix is removed.
+- Version should be the latest date and follow the format `YYYY-MM-DD-preview`. This is the date on which the contribution is made or when the Resource Type is tested and validated, e.g. `2025-07-20-preview`.
 
 - The description property must be populated with developer documentation. The top-level descrption and each property's description are output by `rad resource-type show` and will be visible in the Radius Dashboard in the future. See documentation section for more details.
 
@@ -264,7 +219,7 @@ types:
 
 ### Platform Engineers
 
-Documentation for platform engineers must be provided in a `README.md` file in the Resource Type directory. This README should focus on describing the Recipes and the requirements for building a custom Recipe for the Resource Type. This file should include:
+Documentation for platform engineers must be provided in a `README.md` file in the Resource Type directory. This README should focus on describing the Recipes provided for the Resource Type across the platform Recipe Packs and the requirements for authoring a custom Recipe. This file should include:
 
 ```
 ## Overview
@@ -273,16 +228,13 @@ A brief description of the Resource Type and its purpose.
 
 ## Recipes
 
-A list of available Recipes for this Resource Type, including links to the Bicep and Terraform templates.:
+A list of the Recipes provided for this Resource Type, including the platform Recipe Pack that contains each one and the module the Recipe points to:
 
-|Platform| IaC Language| Recipe Name | Stage |
-|---|---|---|---|
-| AWS | Bicep | aws-memorydb.bicep | Alpha |
-| AWS | Terraform | aws-memorydb/main.tf | Alpha |
-| Azure | Bicep | azure-cache.bicep | Alpha |
-| Azure | Terraform | azure-cache/main.tf | Alpha |
-| Kubernetes | Bicep | kubernetes-redis.bicep | Alpha |
-| Kubernetes | Terraform | kubernetes/main.tf | Alpha |
+| Platform | Recipe Pack | Module Source |
+|---|---|---|
+| Azure | recipepack/azure/bicep-recipepack.bicep | mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise |
+| AWS | recipepack/aws/terraform-recipepack.bicep | ... |
+| Kubernetes | recipepack/kubernetes/bicep-recipepack.bicep | ghcr.io/radius-project/kube-recipes/... |
 
 ## Recipe Input Properties
 
@@ -311,214 +263,91 @@ A brief description of what the Recipe does and how to use it.
 - Provide troubleshooting guidance
 - Link to relevant external documentation
 
-## Recipes for the Resource Type
+## Recipes and Recipe Packs
 
-Radius supports Recipes in both Bicep and Terraform. Create a `recipes` directory under your Resource Type directory, and add platform-specific subdirectories for each IaC language you want to support.
+Recipes for a Resource Type are added to the platform Recipe Packs under `recipepack/` at the repository root. Each platform has its own folder (`azure/`, `aws/`, `kubernetes/`, and `default-kubernetes/`) containing a Bicep-recipes pack and a Terraform-recipes pack (`bicep-recipepack.bicep` and `terraform-recipepack.bicep`). Each Recipe Pack declares a single `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, plus a `Radius.Core/environments` resource that references the pack.
 
- - Familiarize yourself with the IaC language of your choice [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep) or [Terraform](https://developer.hashicorp.com/terraform)
+Today Radius supports Bicep and Terraform Recipe drivers, so a Recipe can be a Bicep template or a Terraform configuration. It can also point to well-maintained community modules like the [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) or the [AWS Terraform modules](https://registry.terraform.io/namespaces/terraform-aws-modules). When pointing at a standard module, Radius resolves any `{{context.*}}` expressions in the Recipe's `parameters` against the resource being deployed and maps the module's outputs onto the resource's read-only properties via the `outputs` field, so no Radius-specific wrapping is required.
+
+ - Familiarize yourself with the IaC language of your choice, [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep) or [Terraform](https://developer.hashicorp.com/terraform)
  - Familiarize yourself with the Radius [Recipe](https://docs.radapp.io/guides/recipes) concept
- - Follow this [how-to guide](https://docs.radapp.io/guides/recipes/howto-author-recipes/) to write your first Recipe, register your Recipe in the Environment
+ - Follow this [how-to guide](https://docs.radapp.io/guides/recipes/howto-author-recipes/) to write your first Recipe
 
-### Example Bicep Recipe for Redis Cache on Kubernetes
+### Example Recipe Pack
+
+The example below shows an Azure Bicep-recipes pack (`recipepack/azure/bicep-recipepack.bicep`) that registers a Recipe for `Radius.Data/redisCaches` pointing at a standard Azure Verified Module, and a Recipe for `Radius.Compute/containers` using a published Kubernetes container recipe. The developer-authored `size` property is mapped onto a concrete SKU, and the module's outputs are mapped back onto the resource's `host`, `port`, and `url` properties.
 
 ```bicep
+extension radius
 
-@description('Information about what resource is calling this Recipe. Generated by Radius. For more information visit https://docs.radapp.dev/operations/custom-recipes/')
-param context object
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
 
-extension kubernetes with {
-  kubeConfig: ''
-  namespace: context.runtime.kubernetes.namespace
-} as kubernetes
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
 
-resource redis 'apps/Deployment@v1' = {
-  metadata: {
-    name: 'redis-${uniqueString(context.resource.id)}'
-  }
-  spec: {
-    selector: {
-      matchLabels: {
-        app: 'redis'
-        resource: context.resource.name
-      }
-    }
-    template: {
-      metadata: {
-        labels: {
-          app: 'redis'
-          resource: context.resource.name
-
-          // Label pods with the Application name so `rad run` can find the logs.
-          'radapp.io/application': context.application == null ? '' : context.application.name
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'redis-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/redisCaches': {
+        kind: 'bicep'
+        // Standard Azure Verified Module, version pinned with `:<tag>`
+        source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
+        parameters: {
+          // Derive the resource name from the Radius context
+          name: '{{context.resource.name}}'
+          // Map the developer-authored `size` enum onto a concrete SKU
+          skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
+          database: {
+            name: 'default'
+            accessKeysAuthentication: 'Enabled'
+          }
+          publicNetworkAccess: 'Enabled'
+          enableTelemetry: false
+        }
+        // Map module outputs onto the resource's read-only properties
+        outputs: {
+          host: 'hostName'
+          port: 'port'
+          url: 'primaryConnectionString'
         }
       }
-      spec: {
-        containers: [
-          {
-            // This container is the running redis instance.
-            name: 'redis'
-            image: 'redis'
-            ports: [
-              {
-                containerPort: 6379
-              }
-            ]
-          }
-          {
-            // This container will connect to redis and stream logs to stdout for aid in development.
-            name: 'redis-monitor'
-            image: 'redis'
-            args: [
-              'redis-cli'
-              '-h'
-              'localhost'
-              'MONITOR'
-            ]
-          }
-        ]
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
       }
     }
   }
 }
 
-resource svc 'core/Service@v1' = {
-  metadata: {
-    name: 'redis-${uniqueString(context.resource.id)}'
-  }
-  spec: {
-    type: 'ClusterIP'
-    selector: {
-      app: 'redis'
-      resource: context.resource.name
-    }
-    ports: [
-      {
-        port: 6379
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'default'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
       }
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
     ]
-  }
-}
-
-output result object = {
-  // This workaround is needed because the deployment engine omits Kubernetes resources from its output.
-  // This allows Kubernetes resources to be cleaned up when the resource is deleted.
-  // Once this gap is addressed, users won't need to do this.
-  resources: [
-    '/planes/kubernetes/local/namespaces/${svc.metadata.namespace}/providers/core/Service/${svc.metadata.name}'
-    '/planes/kubernetes/local/namespaces/${redis.metadata.namespace}/providers/apps/Deployment/${redis.metadata.name}'
-  ]
-  values: {
-    host: '${svc.metadata.name}.${svc.metadata.namespace}.svc.cluster.local'
-    port: 6379
   }
 }
 ```
 
-### Example Terraform Recipe
-
-```hcl
-terraform {
-  required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.0"
-    }
-  }
-}
-
-variable "context" {
-  description = "Radius-provided object containing information about the resource calling the Recipe."
-  type = any
-}
-
-variable "port" {
-  description = "The port Redis is offered on. Defaults to 6379."
-  type = number
-  default = 6379
-}
-
-resource "kubernetes_deployment" "redis" {
-  metadata {
-    name = "redis-${sha512(var.context.resource.id)}"
-    namespace = var.context.runtime.kubernetes.namespace
-    labels = {
-      app = "redis"
-    }
-  }
-  spec {
-    selector {
-      match_labels = {
-        app = "redis"
-        resource = var.context.resource.name
-      }
-    }
-    template {
-      metadata {
-        labels = {
-          app = "redis"
-          resource = var.context.resource.name
-        }
-      }
-      spec {
-        container {
-          name  = "redis"
-          image = "redis:6"
-          port {
-            container_port = 6379
-          }
-        }
-      }
-    }
-  }
-}
-
-resource "kubernetes_service" "redis" {
-  metadata {
-    name = "redis-${sha512(var.context.resource.id)}"
-    namespace = var.context.runtime.kubernetes.namespace
-  }
-  spec {
-    type = "ClusterIP"
-    selector = {
-      app = "redis"
-      resource = var.context.resource.name
-    }
-    port {
-      port        = var.port
-      target_port = "6379"
-    }
-  }
-}
-
-output "result" {
-  value = {
-    values = {
-      host = "${kubernetes_service.metadata.name}.${kubernetes_service.metadata.namespace}.svc.cluster.local"
-      port = kubernetes_service.spec.port[0].port
-      username = ""
-    }
-    secrets = {
-      password = ""
-    }
-    // UCP resource IDs
-    resources = [
-        "/planes/kubernetes/local/namespaces/${kubernetes_service.metadata.namespace}/providers/core/Service/${kubernetes_service.metadata.name}",
-        "/planes/kubernetes/local/namespaces/${kubernetes_deployment.metadata.namespace}/providers/apps/Deployment/${kubernetes_deployment.metadata.name}"
-    ]
-  }
-  description = "The result of the Recipe. Must match the target resource's schema."
-  sensitive = true
-}
-
-```
 ### Recipe Guidelines
 
+- Prefer standard, versioned modules (for example, Azure Verified Modules) where available, and pin the version with the `:<tag>` syntax so deployments are reproducible.
 - Recipes should be idempotent, meaning they can be run multiple times without causing issues.
-- Handle secure defaults for all parameters, especially those related to secrets.
-- Recipes should handle different size/configuration options, allowing users to choose the appropriate configuration for their needs.
-- Provide outputs required to connect to the resource provisioned by the Recipe.
-- Use core Radius Resource Types like `containers`, `gateway` and `secrets` where applicable to ensure consistency and reusability.
-- Use comments to explain complex logic or important decisions in your Recipe code.
+- Map developer-authored properties (such as `size`) onto concrete infrastructure settings using `{{context.*}}` parameter expressions rather than exposing platform-specific properties on the Resource Type.
+- Map every read-only property of the Resource Type from a module output via the `outputs` field so consumers can connect to the provisioned resource.
+- Handle secrets securely: mark sensitive properties `x-radius-sensitive: true` on the Resource Type and never log or expose credentials.
+- The Kubernetes Recipe Pack should be self-contained (in-cluster, no cloud provider configuration) so it can serve as the zero-config `default-kubernetes/` pack.
 
 ## Testing Your Contribution
 
@@ -537,46 +366,43 @@ After creating your Resource Type and Recipes, test them locally using the provi
    make build-resource-type TYPE_FOLDER=Data/redisCaches
    ```
 
-3. **Build your recipes**:
+3. **Deploy the Recipe Pack to configure your Environment**:
+
+   A Recipe Pack declares the `Radius.Core/recipePacks` and `Radius.Core/environments` resources, so deploying it registers the Recipes for every Resource Type it covers in the Environment. Add your Resource Type's Recipe to the pack for your target platform, then deploy that pack. For example, the Azure pack (`recipepack/azure/bicep-recipepack.bicep`) holds the Recipe definitions for all Azure-provisioned types and is deployed with the `rad` CLI, supplying the pack's parameters:
    ```bash
-   # For Bicep recipes
-   make build-bicep-recipe RECIPE_PATH=Data/redisCaches/recipes/kubernetes/bicep
-   
-   # For Terraform recipes
-   make build-terraform-recipe RECIPE_PATH=Data/redisCaches/recipes/kubernetes/terraform
+   # Configure the Radius Azure provider credentials (requires AZURE_* env vars:
+   # AZURE_SUBSCRIPTION_ID, AZURE_RESOURCE_GROUP, AZURE_LOCATION, AZURE_TENANT_ID, AZURE_CLIENT_ID)
+   make configure-azure-provider
+
+   # Deploy the Recipe Pack, supplying its parameters
+   rad deploy recipepack/azure/bicep-recipepack.bicep \
+     --parameters azureSubscriptionId=<subscription-id> \
+     --parameters azureResourceGroup=<resource-group>
    ```
 
-4. **Register your recipes** (required before testing):
-  ```bash
-  # Register Bicep recipes you've built
-  make register RECIPE_TYPE=bicep
+4. **Deploy the test application**:
 
-  # Register Terraform recipes in a separate environment or after cleanup
-  make register RECIPE_TYPE=terraform ENVIRONMENT=my-terraform-env
-  ```
-
-  If you rely on a single Radius environment, run the register → test flow for one IaC format, clean up (or switch environments), and only then repeat for the other format so the two template kinds do not overwrite each other's registrations.
-
-5. **Test individual recipes**:
+   Deploy your Resource Type's test application against the configured Environment:
    ```bash
-   make test-recipe RECIPE_PATH=Data/redisCaches/recipes/kubernetes/bicep
+   rad deploy Data/redisCaches/test/app.bicep
    ```
 
-6. **Test all recipes** (if you have multiple):
+5. **Run the automated tests**:
   ```bash
   make test
   ```
 
-  To scope testing to a specific implementation, set `RECIPE_TYPE` to `bicep` or `terraform` (and optionally override the Radius environment with `ENVIRONMENT`):
-  ```bash
-  make test RECIPE_TYPE=bicep
-  make test RECIPE_TYPE=terraform ENVIRONMENT=my-terraform-env
-  ```
-
-  Remember that `make test` assumes recipes are already registered. To validate both Bicep and Terraform recipes for the same resource type, run those register/test cycles sequentially or in distinct environments to avoid template registration conflicts.
-
 For detailed testing instructions, see [Testing Resource Types and Recipes](testing-resource-types-recipes.md).
 
-## Integration with CI/CD Testing for Stable Resource Types
+## Integration with CI/CD Testing
 
-For resource types categorized in the "Stable" maturity level, automated test coverage is required in the repository's CI/CD pipeline. The contribution guide with the steps to follow to update the automated tests can be found in [Contributing Tests for Stable Resource Types](contributing-resource-types-tests.md)
+Automated test coverage in the repository's CI/CD pipeline is required for Resource Types and their Recipe Packs. The contribution guide with the steps to follow to update the automated tests can be found in [Contributing Tests for Resource Types](contributing-resource-types-tests.md)
+
+## Making a Resource Type a default in Radius
+
+Every Resource Type in this repository can be registered on demand via `rad resource-type create`. A subset are also registered as defaults in Radius, so they are available out of the box without any user action, paired with the zero-config `default-kubernetes/` Recipe Pack. The list of default Resource Types is managed in the [Radius repository](https://github.com/radius-project/radius) via [`deploy/manifest/defaults.yaml`](https://github.com/radius-project/radius/blob/main/deploy/manifest/defaults.yaml).
+
+To make a Resource Type available out of the box as a default:
+
+1. Add the Resource Type manifest to this repository and merge the PR.
+2. In the [Radius repository](https://github.com/radius-project/radius), add the Resource Type to [`deploy/manifest/defaults.yaml`](https://github.com/radius-project/radius/blob/main/deploy/manifest/defaults.yaml), run `make update-resource-types`, and create a PR. Once this PR is merged, the type is available and the Bicep extension is published.

--- a/docs/contributing/contributing-resource-types-tests.md
+++ b/docs/contributing/contributing-resource-types-tests.md
@@ -1,6 +1,6 @@
-# Contributing Tests for Stable Resource Types
+# Contributing Tests for Resource Types
 
-Resource Types at the Stable maturity level are required to integrate with Radius CI/CD testing. This guide explains how to add automated test coverage for your Resource Type so it can be validated in CI/CD pipelines.
+Resource Types that are mature are required to integrate with Radius CI/CD testing. This guide explains how to add automated test coverage for your Resource Type so it can be validated in CI/CD pipelines.
 
 ## Overview
 

--- a/docs/using-resource-types.md
+++ b/docs/using-resource-types.md
@@ -1,0 +1,130 @@
+# Discovering and Using Resource Types and Recipe Packs
+
+This guide is for developers and platform engineers who want to find the Resource Types and Recipe Packs available in this repository and use them with Radius. Developers use Resource Types in their application definitions; platform engineers use Recipe Packs to configure how those types are provisioned in an Environment. If you want to contribute a new Resource Type or Recipe, see [Contributing Resource Types and Recipes](contributing/contributing-resource-types-recipes.md) instead.
+
+## Discovering Resource Types
+
+Resource Types in this repository are organized by category. Each category maps to a `Radius.<Category>` namespace and lives in a top-level directory (for example, `Data/`, `Security/`, `Compute/`). Within a category, each Resource Type has its own folder that contains:
+
+- `<resourceType>.yaml` — the Resource Type definition, including developer documentation and usage examples in its top-level `description`.
+- `README.md` — an overview written for platform engineers, describing the properties a Recipe consumes and produces, and referencing the Recipe Packs and the tested Recipe sources (modules) available for the type.
+- `test/app.bicep` — a runnable example application that uses the Resource Type.
+
+To browse the available types, explore the category directories in this repository, or list them from an environment where they are registered:
+
+```bash
+# List the Resource Types registered in your Radius installation
+rad resource-type list
+
+# Show the developer documentation, properties, and usage examples for a type
+rad resource-type show Radius.Data/mySqlDatabases
+```
+
+The output of `rad resource-type show` includes the Bicep usage example and a description of every property, so it is the fastest way to learn how to use a type once it is registered.
+
+## Registering a Resource Type
+
+Some Resource Types ship as defaults in Radius and are available out of the box (see [Default resource types in Radius](../README.md#default-resource-types-in-radius)). If the type you want is not already registered, register it from its definition:
+
+```bash
+rad resource-type create Radius.Data/mySqlDatabases -f Data/mySqlDatabases/mySqlDatabases.yaml
+```
+
+Registering the type also makes it available in Bicep through the generated extension. Your platform engineer must also configure a Recipe for the type in your Environment — Recipes for this repository are grouped into the platform Recipe Packs under [`recipepack/`](../recipepack).
+
+## Discovering and using Recipe Packs
+
+Recipe Packs live at the repository root under [`recipepack/`](../recipepack). Each platform has its own folder containing a Bicep-recipes pack (`bicep-recipepack.bicep`) and a Terraform-recipes pack (`terraform-recipepack.bicep`):
+
+- `azure/` — recipes for all types provisioned on Azure.
+- `aws/` — recipes for all types provisioned on AWS.
+- `kubernetes/` — recipes for all types provisioned in-cluster on Kubernetes.
+- `default-kubernetes/` — the zero-config, in-cluster default pack that ships out of the box.
+
+Each Recipe Pack bundles the Recipes for every Resource Type on that platform together with an Environment definition, so a platform engineer configures an Environment by deploying a single Recipe Pack instead of registering Recipes one type at a time. Cloud packs (under `azure/` and `aws/`) accept parameters for the provider configuration, such as the subscription or account the Environment provisions into.
+
+Deploy a Recipe Pack to create and configure the Environment:
+
+```bash
+# Configure an Environment with the Azure Bicep-recipes pack
+rad deploy recipepack/azure/bicep-recipepack.bicep
+
+# Or start with the zero-config Kubernetes default
+rad deploy recipepack/default-kubernetes/bicep-recipepack.bicep
+```
+
+After a Recipe Pack is deployed, every Resource Type it covers can be used in an application deployed to that Environment.
+
+## Using a Resource Type in a Radius application
+
+Once a Resource Type is registered and a Recipe is configured in your Environment, add it to your application definition:
+
+1. **Reference the extension** for the Resource Type at the top of your Bicep file.
+2. **Declare the resource**, providing the required properties. `environment` is always required, and `application` is required for types that belong to an application.
+3. **Connect to the resource** from a container,so Radius injects the connection details as environment variables.
+4. **Deploy** the application.
+
+```bicep
+extension radius
+extension mysqlDatabases
+
+@description('The Radius environment ID')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'myapp'
+  properties: {
+    environment: environment
+  }
+}
+
+resource db 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
+  name: 'db'
+  properties: {
+    environment: environment
+    application: app.id
+    database: 'appdb'
+  }
+}
+
+resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'frontend'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      web: {
+        image: 'ghcr.io/radius-project/samples/demo:latest'
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      db: {
+        source: db.id
+      }
+    }
+  }
+}
+```
+
+Deploy the application with the `rad` CLI:
+
+```bash
+rad deploy app.bicep
+```
+
+When a container declares a `connection` to a resource, Radius injects the resource's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_DB_HOST` and `CONNECTION_DB_PORT`).
+
+## Finding examples
+
+Every Resource Type folder includes a `test/app.bicep` that shows a complete, working example, and the type's `README.md` documents its properties. Start from the example for the type you want, then adapt it to your application.
+
+## Learn more
+
+- [Radius documentation](https://docs.radapp.io)
+- [Resource Types tutorial](https://docs.radapp.io/tutorials/create-resource-type/)
+- [Connections between resources](https://docs.radapp.io/guides/author-apps/connections/)

--- a/docs/using-resource-types.md
+++ b/docs/using-resource-types.md
@@ -61,7 +61,7 @@ Once a Resource Type is registered and a Recipe is configured in your Environmen
 
 1. **Reference the extension** for the Resource Type at the top of your Bicep file.
 2. **Declare the resource**, providing the required properties. `environment` is always required, and `application` is required for types that belong to an application.
-3. **Connect to the resource** from a container,so Radius injects the connection details as environment variables.
+3. **Connect to the resource** from a container, so Radius injects the connection details as environment variables.
 4. **Deploy** the application.
 
 ```bicep

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -1,0 +1,42 @@
+# Azure Recipe Pack
+
+This folder contains the **Azure Recipe Pack** — a collection of Recipes that provision Radius Resource Types on Azure, bundled with an Environment definition. Deploying the pack configures a Radius Environment to use the Azure provider and registers the Recipes for every Resource Type it covers.
+
+| File | Description |
+| --- | --- |
+| `bicep-recipepack.bicep` | Recipe Pack wiring the Bicep recipes for all Azure-provisioned types, plus the Environment definition. |
+| `terraform-recipepack.bicep` | Recipe Pack wiring the Terraform recipes for all Azure-provisioned types, plus the Environment definition. |
+
+Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, and a `Radius.Core/environments` resource that references the pack and configures the Azure provider.
+
+## Recipes in this pack
+
+| Resource Type | Kind | Source |
+| --- | --- | --- |
+| `Radius.Data/redisCaches` | Bicep | Azure Verified Module — `avm/res/cache/redis-enterprise` |
+| `Radius.Compute/containers` | Bicep | `ghcr.io/radius-project/kube-recipes/containers` |
+
+## Parameters
+
+The Azure pack accepts the provider configuration and per-recipe inputs it needs to provision into your subscription:
+
+| Parameter | Description |
+| --- | --- |
+| `azureSubscriptionId` | Azure subscription ID the Environment provisions resources into. |
+| `azureResourceGroup` | Existing Azure resource group the Environment provisions resources into. |
+
+## Deploying
+
+Deploy the pack with the `rad` CLI, supplying the parameters it requires. Deploying the file creates the `Radius.Core/recipePacks` resource and configures the `default` Environment to use it:
+
+```bash
+rad deploy recipepack/azure/bicep-recipepack.bicep \
+  --parameters azureSubscriptionId=<subscription-id> \
+  --parameters azureResourceGroup=<resource-group>
+```
+
+After the pack is deployed, every Resource Type it covers can be used in an application deployed to that Environment.
+
+## Contributing a Recipe
+
+To add a Recipe for another Resource Type to this pack, add an entry to the `recipes` map keyed by the Resource Type (for example `Radius.Data/redisCaches`). For guidance on writing Recipes and wiring them into a Recipe Pack, see [Contributing Resource Types and Radius Recipes](../../docs/contributing/contributing-resource-types-recipes.md#recipes-and-recipe-packs).

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -1,0 +1,57 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'redis-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/redisCaches': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
+        parameters: {
+          name: '{{context.resource.name}}'
+          skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
+          highAvailability: 'Disabled'
+          database: {
+            name: 'default'
+            accessKeysAuthentication: 'Enabled'
+          }
+          publicNetworkAccess: 'Enabled'
+          enableTelemetry: false
+        }
+        outputs: {
+          host: 'hostName'
+          port: 'port'
+          url: 'primaryConnectionString'
+        }
+      }
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containers:latest'
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'default'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds a new `Radius.Data/redisCaches` Resource Type along with an Azure Recipe Pack, and revamps the contributor and usage documentation around the Recipe Pack model.

Highlights:
- New `Radius.Data/redisCaches` Resource Type definition (`Data/redisCaches/redisCaches.yaml`), README, and `test/app.bicep`.
- New Azure Recipe Pack (`recipepack/azure/`) with `bicep-recipepack.bicep` and README.
- Documentation updates: revamped `docs/contributing/contributing-resource-types-recipes.md` and top-level `README.md` for the Recipe Pack model, plus a new `docs/using-resource-types.md` guide.

Related GitHub Issue: N/A

## Testing

- Verify `rad resource-type show Radius.Data/redisCaches` renders the definition correctly.
- Deploy `Data/redisCaches/test/app.bicep` against an environment configured with the Azure Recipe Pack.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] Platform engineer documentation is in README.md
- [x] Developer documentation is the top-level description property
- [x] Example of defining the Resource Type is in the developer documentation
- [x] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [x] All properties in the Resource Type definition have clear descriptions
- [x] Enum properties have values defined in `enum: []`
- [x] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [x] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [x] Recipes include a results output variable with all read-only properties set
- [x] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the Recipe context object when possible
- [x] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [x] Recipes are idempotent
- [ ] Resource types and recipes were tested
