### PR TITLE
Add redisCaches Azure Recipe Pack and adopt the Recipe Pack model

### DIFF
--- a/Data/redisCaches/README.md
+++ b/Data/redisCaches/README.md
@@ -1,0 +1,30 @@
+# Radius.Data/redisCaches
+
+## Overview
+
+The **Radius.Data/redisCaches** resource type represents a Redis cache. It allows developers to create and easily connect to a Redis cache as part of their Radius applications. Unlike database types, no secret is required — Azure Managed Redis generates its own access keys, so the platform's Recipe provisions a cache without any injected credentials.
+
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.Data/redisCaches` command.
+
+## Properties
+
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `size` | string (`S` \| `M` \| `L`) | Optional | The size of the Redis cache. Defaults to `S`. The Recipe maps the size onto a concrete cloud SKU. |
+| `host` | string | Read only | The host name used to connect to the cache. Set from the Recipe module's output. |
+| `port` | integer | Read only | The TLS port used to connect to the cache. Azure Managed Redis serves on 10000. |
+| `url` | string | Read only | The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`), including the access key. Set from the Recipe module's `primaryConnectionString` output. |
+
+## Recipe Packs
+
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.Data/redisCaches` along with the Recipes for every other Resource Type on that platform.
+
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1` |
+
+## Using the resource type
+
+Add a `redisCaches` resource to your application and connect a container to it. Radius injects the cache's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_REDIS_HOST`, `CONNECTION_REDIS_PORT`, and `CONNECTION_REDIS_URL`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Data/redisCaches/redisCaches.yaml
+++ b/Data/redisCaches/redisCaches.yaml
@@ -1,0 +1,77 @@
+namespace: Radius.Data
+types:
+  redisCaches:
+    description: |
+      The Radius.Data/redisCaches Resource Type deploys a Redis cache. To deploy a
+      Redis cache, add a redisCaches resource to the application definition Bicep
+      file. Unlike database types, no secret is required: Azure Managed Redis
+      generates its own access keys, so the platform-engineer recipe needs no
+      injected credentials.
+      ```
+      resource cache 'Radius.Data/redisCaches@2025-08-01-preview' = {
+        name: 'redis'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          size: 'S'
+        }
+      }
+      ```
+
+      To connect your container to the cache, create a connection from the
+      Container resource to the cache as shown below.
+      ```
+      resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'frontend'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          container: {
+            image: 'frontend:1.25'
+          }
+          connections: {
+            redis: {
+              source: cache.id
+            }
+          }
+        }
+      }
+      ```
+
+      The connection automatically injects environment variables into the
+      container for all properties from the cache. The environment variables are
+      named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example the
+      connection name is `redis` so the environment variables will be:
+
+      - CONNECTION_REDIS_HOST
+      - CONNECTION_REDIS_PORT
+      - CONNECTION_REDIS_URL
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
+            application:
+              type: string
+              description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            size:
+              type: string
+              enum: ['S', 'M', 'L']
+              description: "(Optional) The size of the Redis cache. Defaults to `S` if not provided. The recipe maps the size onto a concrete cloud SKU."
+            host:
+              type: string
+              description: The host name used to connect to the cache. Mapped from the recipe module's output.
+              readOnly: true
+            port:
+              type: integer
+              description: The TLS port number used to connect to the cache. Mapped from the recipe module's `port` output (Azure Managed Redis uses 10000).
+              readOnly: true
+            url:
+              type: string
+              description: The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output.
+              readOnly: true
+          required: [environment]

--- a/Data/redisCaches/test/app.bicep
+++ b/Data/redisCaches/test/app.bicep
@@ -1,0 +1,45 @@
+extension radius
+
+extension redisCaches
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'redis-azure-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource redis 'Radius.Data/redisCaches@2025-08-01-preview' = {
+  name: 'redis'
+  properties: {
+    environment: environment
+    application: app.id
+    size: 'S'
+  }
+}
+
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      demo: {
+        image: 'ghcr.io/radius-project/samples/demo:latest'
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      redis: {
+        source: redis.id
+      }
+    }
+  }
+}

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -12,7 +12,8 @@ Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map cont
 
 | Resource Type | Kind | Source |
 | --- | --- | --- |
-| `Radius.Data/sqlServerDatabases` | Bicep | Azure Verified Module — `mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4` |
+| `Radius.Data/redisCaches` | Bicep | Azure Verified Module — `mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1` |
+| `Radius.Data/sqlServerDatabases` | Bicep | Azure Verified Module — `avm/res/sql/server` |
 | `Radius.Data/postgreSqlDatabases` | Bicep | Azure Verified Module — `avm/res/db-for-postgre-sql/flexible-server` |
 | `Radius.AI/search` | Bicep | Azure Verified Module — `avm/res/search/search-service` |
 | `Radius.Messaging/rabbitMQ` | Bicep | Azure Verified Module — `avm/res/service-bus/namespace` |

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -1,21 +1,25 @@
-// Platform-engineer baseline for verifying Radius.Data/sqlServerDatabases on Azure via
-// a STANDARD Azure Verified Module (AVM) — no Radius wrapper recipe. Radius
-// resolves {{context.*}} expressions in `parameters`, runs the AVM through the
-// Bicep driver + deployment engine, and maps plain module outputs onto resource
-// properties via `outputs`.
+// Platform-engineer baseline for verifying Radius.Data/redisCaches on Azure via a
+// STANDARD Azure Verified Module (AVM) — no Radius wrapper recipe. Radius resolves
+// {{context.*}} expressions in `parameters`, runs the AVM through the Bicep driver
+// + deployment engine, and maps plain module outputs onto resource properties via
+// `outputs` (host <- hostName, port <- port, url <- primaryConnectionString).
 //
-// Credentials: the developer authors the administrator `username` and `password`
-// directly on the sqlServerDatabases resource (app.bicep). `password` is marked
-// `x-radius-sensitive`, so Radius encrypts it at rest, redacts it on reads, and
-// exposes it decrypted only to this recipe as
-// {{context.resource.properties.username/password}}, wired onto the AVM's
-// administratorLogin/administratorLoginPassword below.
+// Credentials: unlike database types, redisCaches needs no injected secret. Azure
+// Managed Redis generates its own access keys; the recipe enables access-key
+// authentication so the module emits a ready-to-use connection string.
 //
-// Portability: this schema is platform-neutral. For AWS RDS SQL Server, a
-// Terraform recipe would map `host` from the DB instance endpoint/address and pass
-// the same username/password through. For Kubernetes, a recipe could deploy an mssql
-// container or StatefulSet, expose it with a Service DNS name for `host`, and set
-// `port` to 1433.
+// Module choice: this pack uses AZURE MANAGED REDIS (`avm/res/cache/redis-enterprise`),
+// NOT classic Azure Cache for Redis (`avm/res/cache/redis`). Classic Azure Cache
+// for Redis cannot disable AUTH on a public cache and its AVM module emits no
+// access-key/connection-string output (only a Key Vault export), so a connecting
+// app can never obtain a credential. Azure Managed Redis (Redis Enterprise,
+// `Balanced_*` SKUs) supports access-key auth and its AVM module emits
+// `primaryConnectionString` (a ready-to-use `rediss://` URL) mapped onto `url`.
+//
+// Portability: this schema is platform-neutral. For AWS ElastiCache a Terraform
+// recipe would map `host`/`port` from the cluster endpoint and build `url`. For
+// Kubernetes a recipe could deploy a redis container/StatefulSet, expose it with a
+// Service DNS name for `host`, and set `port` to 6379.
 
 extension radius
 
@@ -26,49 +30,56 @@ param azureSubscriptionId string
 param azureResourceGroup string
 
 resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
-  name: 'sqlserver-azure-avm'
+  name: 'redis-azure-avm'
   properties: {
     recipes: {
-      'Radius.Data/sqlServerDatabases': {
+      'Radius.Data/redisCaches': {
         kind: 'bicep'
         // Standard Azure Verified Module, version pinned with `:<tag>`
-        // (https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/sql/server).
-        source: 'mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4'
+        // (https://github.com/Azure/bicep-registry-modules/tree/main/avm/res/cache/redis-enterprise).
+        source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
         parameters: {
           name: '{{context.resource.name}}'
-          administratorLogin: '{{context.resource.properties.username}}'
-          administratorLoginPassword: '{{context.resource.properties.password}}'
+          // Map the developer-authored `size` enum (S|M|L) onto a concrete Azure
+          // Managed Redis SKU via {{context.*}} parameter expression resolution; the
+          // recipe engine resolves these per deployed resource. The resolver
+          // currently supports single-level ternaries (radius-project/radius#12238),
+          // so M and L collapse to the same (next) SKU. `Balanced_B0` is the
+          // smallest Azure Managed Redis SKU.
+          skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
+          // Single replica — no high-availability replication. Only honoured on
+          // Azure Managed Redis SKUs.
+          highAvailability: 'Disabled'
+          // Create the default database with access-key authentication enabled. This
+          // is what makes the module emit `primaryAccessKey`/`primaryConnectionString`
+          // (gated on `accessKeysAuthentication == 'Enabled'`), giving a connecting
+          // app a credential. Clients connect over TLS (`rediss://`).
+          database: {
+            name: 'default'
+            accessKeysAuthentication: 'Enabled'
+          }
+          // Public access keeps the pack self-contained (no VNet integration).
           publicNetworkAccess: 'Enabled'
-          firewallRules: [
-            {
-              name: 'AllowAllWindowsAzureIps'
-              startIpAddress: '0.0.0.0'
-              endIpAddress: '0.0.0.0'
-            }
-          ]
-          databases: [
-            {
-              name: '{{context.resource.properties.database}}'
-              availabilityZone: -1
-              sku: {
-                name: 'Basic'
-                tier: 'Basic'
-              }
-              maxSizeBytes: 2147483648
-              zoneRedundant: false
-            }
-          ]
+          // AVM modules emit a Microsoft.Resources/deployments telemetry resource
+          // the Radius Bicep deployment engine can't process at location "global".
+          // Disabling telemetry skips it — the AVM-sanctioned opt-out.
           enableTelemetry: false
         }
-        // Map the module's FQDN output onto the resource's `host` property. The
-        // AVM has no port output; Azure SQL Database uses the fixed TCP port 1433.
+        // Map the module's outputs onto the resource's properties.
+        //   host <- hostName  (the cluster host, e.g. <name>.<region>.redis.azure.net)
+        //   port <- port      (an int; Azure Managed Redis serves on 10000)
+        //   url  <- primaryConnectionString  (a ready-to-use `rediss://:<key>@host:10000` TLS URL)
         outputs: {
-          host: 'fullyQualifiedDomainName'
+          host: 'hostName'
+          port: 'port'
+          url: 'primaryConnectionString'
         }
       }
       // Radius.Compute/containers is a default type but needs a recipe to deploy.
-      // The published Kubernetes container recipe materializes the golang-migrate
-      // client (which connects to the Azure SQL database) as a Kubernetes Deployment.
+      // The published Kubernetes container recipe materializes the container as a
+      // Kubernetes Deployment and turns its `connections` to the redisCaches
+      // resource into CONNECTION_REDIS_* environment variables (host/port/url) the
+      // app reads to connect.
       'Radius.Compute/containers': {
         kind: 'bicep'
         source: 'ghcr.io/radius-project/kube-recipes/containers:latest'


### PR DESCRIPTION
## Summary

Adds the **`Radius.Data/redisCaches`** resource type and its **Azure Recipe Pack**, following the Recipe Pack model (mirrors #206 for sqlServerDatabases). The recipe provisions **Azure Managed Redis (Redis Enterprise)** via the AVM `res/cache/redis-enterprise:0.5.1` direct module and maps the module outputs onto the resource's connection properties.

## Files

| File | Description |
| --- | --- |
| `Data/redisCaches/redisCaches.yaml` | Resource type definition (`size` S/M/L; read-only `host`/`port`/`url`). |
| `Data/redisCaches/README.md` | Type overview, properties, and Recipe Pack reference. |
| `Data/redisCaches/test/app.bicep` | Example app: a `redisCaches` resource + a container connected to it. |
| `recipepack/azure/bicep-recipepack.bicep` | Azure Recipe Pack entry for `Radius.Data/redisCaches` (+ containers) and the Environment definition. |
| `recipepack/azure/README.md` | Adds the `redisCaches` row to the pack's recipe table. |

## Design notes

- **No injected secret.** Unlike database types, `redisCaches` needs no credential. Azure Managed Redis generates its own access keys; the recipe enables `accessKeysAuthentication` so the module emits `primaryConnectionString` (a ready-to-use `rediss://` TLS URL), mapped onto the read-only `url` property.
- **`size` -> SKU.** The developer `size` enum (S/M/L) is mapped onto a concrete Azure Managed Redis SKU via `{{context.*}}` parameter resolution. The resolver currently supports single-level ternaries (radius-project/radius#12238), so M and L collapse to the same next SKU.
- **Module choice.** Uses Azure Managed Redis (Redis Enterprise), not classic Azure Cache for Redis — the classic module can't disable AUTH on a public cache and emits no access-key/connection-string output, so a connecting app could never obtain a credential.
- **Output mapping.** `host <- hostName`, `port <- port`, `url <- primaryConnectionString`.

## Verification

The type + recipe were verified end-to-end against a **real Azure Managed Redis deployment** using the direct-module feature: provisioning succeeded and all three outputs (`host`/`port`/`url`) resolved onto the resource.

## Notes for reviewers

- Overlaps with #199, which also introduces `Data/redisCaches`. This PR carries the version validated against a real Azure deployment; the two should be reconciled before merge.
- Like the other Recipe Pack PRs (#200-#206), this writes to the shared `recipepack/azure/bicep-recipepack.bicep` and `README.md`. Whichever merges first, the others need a trivial merge to combine the `recipes` entries.
