### PR TITLE
Add Radius.AI/models resource type and Azure recipe

### DIFF
--- a/AI/models/README.md
+++ b/AI/models/README.md
@@ -1,0 +1,29 @@
+# Radius.AI/models
+
+## Overview
+
+The **Radius.AI/models** resource type represents an LLM inference model endpoint. It allows developers to provision and connect to a managed model service as part of their Radius applications. The resource has no developer-authored credentials; the platform Recipe provisions the concrete model service and maps its endpoint and API key back onto read-only resource properties for connections.
+
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.AI/models` command.
+
+## Properties
+
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `model` | string | Optional | The model deployment to provision. Defaults to `gpt-5-mini`. |
+| `endpoint` | string | Read only | The base URL used to call the model inference endpoint. Set from the Recipe module's output. |
+| `apiKey` | string | Read only | The API key used to call the model inference endpoint. Set from the Recipe module's output. |
+
+## Recipe Packs
+
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.AI/models` along with the Recipes for every other Resource Type on that platform.
+
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `mcr.microsoft.com/bicep/avm/res/cognitive-services/account:0.15.0` |
+
+## Using the resource type
+
+Add a `models` resource to your application and connect a container to it. Radius injects the model's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_LLM_MODEL`, `CONNECTION_LLM_ENDPOINT`, and `CONNECTION_LLM_APIKEY`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/AI/models/models.yaml
+++ b/AI/models/models.yaml
@@ -1,0 +1,74 @@
+namespace: Radius.AI
+types:
+  models:
+    description: |
+      The Radius.AI/models Resource Type deploys an LLM inference model endpoint.
+      To deploy a model, add a models resource to the application definition Bicep
+      file. The platform-engineer recipe binds this developer-facing contract to a
+      managed cloud model service without exposing any module details to the app.
+      ```
+      resource model 'Radius.AI/models@2025-08-01-preview' = {
+        name: 'model'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          model: 'gpt-5-mini'
+        }
+      }
+      ```
+
+      To connect your container to the model, create a connection from the
+      Container resource to the model as shown below.
+      ```
+      resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'frontend'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          containers: {
+            frontend: {
+              image: 'frontend:1.25'
+            }
+          }
+          connections: {
+            llm: {
+              source: model.id
+            }
+          }
+        }
+      }
+      ```
+
+      The connection automatically injects environment variables into the
+      container for all properties from the model. The environment variables are
+      named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example the
+      connection name is `llm` so the environment variables will be:
+
+      - CONNECTION_LLM_MODEL
+      - CONNECTION_LLM_ENDPOINT
+      - CONNECTION_LLM_APIKEY
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
+            application:
+              type: string
+              description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            model:
+              type: string
+              default: gpt-5-mini
+              description: "(Optional) The model deployment to provision. Defaults to `gpt-5-mini` if not provided."
+            endpoint:
+              type: string
+              description: "(Read Only) The base URL used to call the model inference endpoint. Mapped from the recipe module's output."
+              readOnly: true
+            apiKey:
+              type: string
+              description: "(Read Only) The API key used to call the model inference endpoint. Mapped from the recipe module's `primaryKey` output."
+              readOnly: true
+          required: [environment]

--- a/AI/models/test/app.bicep
+++ b/AI/models/test/app.bicep
@@ -1,23 +1,23 @@
 extension radius
 
-extension rabbitMQ
+extension models
 
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 
 resource app 'Radius.Core/applications@2025-08-01-preview' = {
-  name: 'rabbitmq-azure-test'
+  name: 'models-azure-test'
   properties: {
     environment: environment
   }
 }
 
-resource queue 'Radius.Messaging/rabbitMQ@2025-08-01-preview' = {
-  name: 'rabbitmq'
+resource model 'Radius.AI/models@2025-08-01-preview' = {
+  name: 'model'
   properties: {
     environment: environment
     application: app.id
-    queue: 'jobs'
+    model: 'gpt-5-mini'
   }
 }
 
@@ -37,8 +37,8 @@ resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
       }
     }
     connections: {
-      rabbitmq: {
-        source: queue.id
+      llm: {
+        source: model.id
       }
     }
   }

--- a/AI/search/test/app.bicep
+++ b/AI/search/test/app.bicep
@@ -20,8 +20,8 @@ resource searchService 'Radius.AI/search@2025-08-01-preview' = {
   }
 }
 
-resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'democtr'
+resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democontainer'
   properties: {
     environment: environment
     application: app.id

--- a/Data/mongoDatabases/test/app.bicep
+++ b/Data/mongoDatabases/test/app.bicep
@@ -23,8 +23,8 @@ resource mongo 'Radius.Data/mongoDatabases@2025-08-01-preview' = {
   }
 }
 
-resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'democtr'
+resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democontainer'
   properties: {
     environment: environment
     application: app.id

--- a/Data/mySqlDatabases/test/app.bicep
+++ b/Data/mySqlDatabases/test/app.bicep
@@ -28,8 +28,8 @@ resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
   }
 }
 
-resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'democtr'
+resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democontainer'
   properties: {
     environment: environment
     application: app.id

--- a/Data/postgreSqlDatabases/test/app.bicep
+++ b/Data/postgreSqlDatabases/test/app.bicep
@@ -28,8 +28,8 @@ resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
   }
 }
 
-resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'democtr'
+resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democontainer'
   properties: {
     environment: environment
     application: app.id

--- a/Data/redisCaches/test/app.bicep
+++ b/Data/redisCaches/test/app.bicep
@@ -21,8 +21,8 @@ resource redis 'Radius.Data/redisCaches@2025-08-01-preview' = {
   }
 }
 
-resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'democtr'
+resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democontainer'
   properties: {
     environment: environment
     application: app.id

--- a/Data/sqlServerDatabases/test/app.bicep
+++ b/Data/sqlServerDatabases/test/app.bicep
@@ -31,8 +31,8 @@ resource sqlserver 'Radius.Data/sqlServerDatabases@2025-08-01-preview' = {
   }
 }
 
-resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'democtr'
+resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democontainer'
   properties: {
     environment: environment
     application: app.id

--- a/Messaging/kafka/test/app.bicep
+++ b/Messaging/kafka/test/app.bicep
@@ -21,8 +21,8 @@ resource kafkaBroker 'Radius.Messaging/kafka@2025-08-01-preview' = {
   }
 }
 
-resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'democtr'
+resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democontainer'
   properties: {
     environment: environment
     application: app.id

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -15,6 +15,7 @@ Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map cont
 | `Radius.Data/sqlServerDatabases` | Bicep | Azure Verified Module — `mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4` |
 | `Radius.Data/postgreSqlDatabases` | Bicep | Azure Verified Module — `avm/res/db-for-postgre-sql/flexible-server` |
 | `Radius.AI/search` | Bicep | Azure Verified Module — `avm/res/search/search-service` |
+| `Radius.AI/models` | Bicep | Azure Verified Module — `avm/res/cognitive-services/account` |
 | `Radius.Messaging/rabbitMQ` | Bicep | Azure Verified Module — `avm/res/service-bus/namespace` |
 | `Radius.Messaging/kafka` | Bicep | Azure Verified Module — `avm/res/event-hub/namespace` |
 | `Radius.Data/mongoDatabases` | Bicep | Azure Verified Module — `avm/res/document-db/database-account` |

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -20,6 +20,7 @@ Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map cont
 | `Radius.Messaging/kafka` | Bicep | Azure Verified Module — `avm/res/event-hub/namespace` |
 | `Radius.Data/mongoDatabases` | Bicep | Azure Verified Module — `avm/res/document-db/database-account` |
 | `Radius.Data/mySqlDatabases` | Bicep | Azure Verified Module — `avm/res/db-for-my-sql/flexible-server` |
+| `Radius.Data/redisCaches` | Bicep | Azure Verified Module — `avm/res/cache/redis-enterprise` |
 | `Radius.Compute/containers` | Bicep | `ghcr.io/radius-project/kube-recipes/containers` |
 
 ## Parameters

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -7,7 +7,7 @@ param azureSubscriptionId string
 param azureResourceGroup string
 
 resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
-  name: 'redis-azure-avm'
+  name: 'azure-avm'
   properties: {
     recipes: {
       'Radius.Data/redisCaches': {
@@ -59,6 +59,192 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         outputs: {
           endpoint: 'endpoint'
           apiKey: 'primaryKey'
+        }
+      }
+      'Radius.AI/search': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/search/search-service:0.12.2'
+        parameters: {
+          name: '{{context.resource.name}}'
+          sku: 'basic'
+          disableLocalAuth: false
+          replicaCount: 1
+          partitionCount: 1
+          enableTelemetry: false
+        }
+        outputs: {
+          endpoint: 'endpoint'
+          apiKey: 'primaryKey'
+        }
+      }
+      'Radius.Data/mongoDatabases': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/document-db/database-account:0.19.0'
+        parameters: {
+          name: '{{context.resource.name}}'
+          capabilitiesToAdd: [
+            'EnableMongo'
+          ]
+          mongodbDatabases: [
+            {
+              name: '{{context.resource.properties.database}}'
+            }
+          ]
+          networkRestrictions: {
+            ipRules: []
+            publicNetworkAccess: 'Enabled'
+          }
+          enableTelemetry: false
+        }
+        outputs: {
+          endpoint: 'endpoint'
+          connectionString: 'primaryReadWriteConnectionString'
+        }
+      }
+      'Radius.Data/mySqlDatabases': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/db-for-my-sql/flexible-server:0.10.3'
+        parameters: {
+          name: '{{context.resource.name}}'
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+          skuName: 'Standard_B1ms'
+          tier: 'Burstable'
+          version: '{{context.resource.properties.version == "5.7" ? "5.7" : "8.0.21"}}'
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+            }
+          ]
+          availabilityZone: -1
+          highAvailability: 'Disabled'
+          geoRedundantBackup: 'Disabled'
+          storageSizeGB: 32
+          publicNetworkAccess: 'Enabled'
+          firewallRules: [
+            {
+              name: 'allow-all'
+              startIpAddress: '0.0.0.0'
+              endIpAddress: '255.255.255.255'
+            }
+          ]
+          enableTelemetry: false
+        }
+        outputs: {
+          host: 'fqdn'
+        }
+      }
+      'Radius.Data/postgreSqlDatabases': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/db-for-postgre-sql/flexible-server:0.15.2'
+        parameters: {
+          name: '{{context.resource.name}}'
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+          authConfig: {
+            activeDirectoryAuth: 'Enabled'
+            passwordAuth: 'Enabled'
+          }
+          skuName: '{{context.resource.properties.size == "S" ? "Standard_B1ms" : "Standard_D2ds_v5"}}'
+          tier: '{{context.resource.properties.size == "S" ? "Burstable" : "GeneralPurpose"}}'
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+            }
+          ]
+          version: '16'
+          availabilityZone: -1
+          highAvailability: 'Disabled'
+          geoRedundantBackup: 'Disabled'
+          storageSizeGB: 32
+          publicNetworkAccess: 'Enabled'
+          firewallRules: [
+            {
+              name: 'allow-all'
+              startIpAddress: '0.0.0.0'
+              endIpAddress: '255.255.255.255'
+            }
+          ]
+          enableAdvancedThreatProtection: false
+          enableTelemetry: false
+        }
+        outputs: {
+          host: 'fqdn'
+        }
+      }
+      'Radius.Data/sqlServerDatabases': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4'
+        parameters: {
+          name: '{{context.resource.name}}'
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+          publicNetworkAccess: 'Enabled'
+          firewallRules: [
+            {
+              name: 'AllowAllWindowsAzureIps'
+              startIpAddress: '0.0.0.0'
+              endIpAddress: '0.0.0.0'
+            }
+          ]
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+              availabilityZone: -1
+              sku: {
+                name: 'Basic'
+                tier: 'Basic'
+              }
+              maxSizeBytes: 2147483648
+              zoneRedundant: false
+            }
+          ]
+          enableTelemetry: false
+        }
+        outputs: {
+          host: 'fullyQualifiedDomainName'
+        }
+      }
+      'Radius.Messaging/rabbitMQ': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/service-bus/namespace:0.16.2'
+        parameters: {
+          name: '{{context.resource.name}}'
+          skuObject: {
+            name: 'Standard'
+          }
+          zoneRedundant: false
+          disableLocalAuth: false
+          queues: [
+            {
+              name: '{{context.resource.properties.queue}}'
+            }
+          ]
+          enableTelemetry: false
+        }
+        outputs: {
+          host: 'name'
+          connectionString: 'primaryConnectionString'
+        }
+      }
+      'Radius.Messaging/kafka': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/event-hub/namespace:0.14.2'
+        parameters: {
+          name: '{{context.resource.name}}'
+          skuName: 'Standard'
+          skuCapacity: 1
+          disableLocalAuth: false
+          eventhubs: [
+            {
+              name: '{{context.resource.properties.topic}}'
+            }
+          ]
+          enableTelemetry: false
+        }
+        outputs: {
+          host: 'name'
+          connectionString: 'primaryConnectionString'
         }
       }
       'Radius.Compute/containers': {

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -30,6 +30,37 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
           url: 'primaryConnectionString'
         }
       }
+      'Radius.AI/models': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/cognitive-services/account:0.15.0'
+        parameters: {
+          name: '{{context.resource.name}}'
+          kind: 'OpenAI'
+          sku: 'S0'
+          customSubDomainName: '{{context.resource.name}}'
+          disableLocalAuth: false
+          publicNetworkAccess: 'Enabled'
+          deployments: [
+            {
+              name: 'chat'
+              model: {
+                format: 'OpenAI'
+                name: '{{context.resource.properties.model}}'
+                version: '2025-08-07'
+              }
+              sku: {
+                name: 'GlobalStandard'
+                capacity: 1
+              }
+            }
+          ]
+          enableTelemetry: false
+        }
+        outputs: {
+          endpoint: 'endpoint'
+          apiKey: 'primaryKey'
+        }
+      }
       'Radius.Compute/containers': {
         kind: 'bicep'
         source: 'ghcr.io/radius-project/kube-recipes/containers:latest'


### PR DESCRIPTION
## Description

Adds a new `Radius.AI/models` Resource Type for provisioning an LLM inference model endpoint, and wires an Azure Recipe into the Azure Recipe Pack.

The developer-facing contract is a single `model` knob plus read-only `endpoint` and `apiKey` properties. On Azure, the platform-engineer Recipe binds this to the `cognitive-services/account` Azure Verified Module (Azure OpenAI) with a `chat` deployment, mapping the module's `endpoint` and `primaryKey` outputs onto the resource. The schema is platform-neutral so the same type can later map to AWS Bedrock or Kubernetes recipes.

Adapted from the `Radius.AI/models` verification app in `radius-project/resource-types-verification` (`tests/llm`).

Changes:
- New `AI/models/` Resource Type: `models.yaml`, `README.md`, and `test/app.bicep`.
- New Azure Recipe entry for `Radius.AI/models` in `recipepack/azure/bicep-recipepack.bicep`, plus README update.
- Renamed the demo test containers to full, consistent names (`democontainer`) across all `test/app.bicep` files.

Related GitHub Issue: N/A

## Testing

- Verify `rad resource-type show Radius.AI/models` renders the definition correctly.
- Deploy the Azure Recipe Pack, then deploy `AI/models/test/app.bicep` against that environment (Azure OpenAI has region/subscription-specific quota for the model).

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] Platform engineer documentation is in README.md
- [x] Developer documentation is the top-level description property
- [x] Example of defining the Resource Type is in the developer documentation
- [x] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [x] All properties in the Resource Type definition have clear descriptions
- [x] Enum properties have values defined in `enum: []`
- [x] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [x] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [x] Recipes include a results output variable with all read-only properties set
- [x] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the Recipe context object when possible
- [x] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [x] Recipes are idempotent
- [ ] Resource types and recipes were tested
