### PR TITLE
Add objectStorage resource type and Azure Recipe Pack entry

### DIFF
--- a/Storage/objectStorage/README.md
+++ b/Storage/objectStorage/README.md
@@ -1,0 +1,33 @@
+# Radius.Storage/objectStorage
+
+## Overview
+
+The **Radius.Storage/objectStorage** resource type represents an object storage container (an S3-style bucket / Azure Blob container / GCS bucket). It allows developers to create and easily connect to object storage as part of their Radius applications. Unlike database types, no secret is required from the developer — Azure Storage generates its own account keys, so the platform's Recipe provisions the account without any injected credentials.
+
+Developer documentation is embedded in the resource type definition YAML file and is accessible via the `rad resource-type show Radius.Storage/objectStorage` command.
+
+## Properties
+
+| Property | Type | Access | Description |
+| --- | --- | --- | --- |
+| `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
+| `application` | string | Optional | The Radius Application ID. |
+| `containerName` | string | Optional | The object container (blob container / S3 bucket) name to create inside the storage account. Defaults to `data`. |
+| `endpoint` | string | Read only | The object storage endpoint. Set from the Recipe module's `primaryBlobEndpoint` output. |
+| `connectionString` | string | Read only | The storage account connection string. Set from the Recipe module's `primaryConnectionString` output. |
+| `accountName` | string | Read only | The Azure Storage account name. Set from the Recipe module's `name` output. |
+| `accountKey` | string | Read only | The Azure Storage account access key. Set from the Recipe module's `primaryAccessKey` output. |
+
+The schema is platform-neutral: the same developer-facing properties can be backed by Azure Blob Storage, AWS S3, or a Kubernetes object-store recipe by changing only the platform recipe's module source, parameters, and outputs.
+
+## Recipe Packs
+
+Recipes for this resource type are provided through the platform Recipe Packs at the repository root under [`recipepack/`](../../recipepack). A platform engineer configures an Environment by deploying the Recipe Pack for their target platform, which registers the Recipe for `Radius.Storage/objectStorage` along with the Recipes for every other Resource Type on that platform.
+
+| Platform | Recipe Pack | Recipe source |
+| --- | --- | --- |
+| Azure | [`recipepack/azure/bicep-recipepack.bicep`](../../recipepack/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `mcr.microsoft.com/bicep/avm/res/storage/storage-account:0.32.1` |
+
+## Using the resource type
+
+Add an `objectStorage` resource to your application and connect a container to it. Radius injects the store's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_STORAGE_ENDPOINT`, `CONNECTION_STORAGE_ACCOUNTNAME`, and `CONNECTION_STORAGE_CONTAINERNAME`). See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Storage/objectStorage/objectStorage.yaml
+++ b/Storage/objectStorage/objectStorage.yaml
@@ -1,0 +1,89 @@
+namespace: Radius.Storage
+types:
+  objectStorage:
+    description: |
+      The Radius.Storage/objectStorage Resource Type deploys an object storage
+      container (an S3-style bucket / Azure Blob container / GCS bucket). To deploy
+      one, add an objectStorage resource to the application definition Bicep file.
+      Unlike database types, no secret is required from the developer: Azure Storage
+      generates its own account keys, so the platform-engineer recipe needs no
+      injected credentials.
+      ```
+      resource store 'Radius.Storage/objectStorage@2025-08-01-preview' = {
+        name: 'store'
+        properties: {
+          environment: environment
+          application: myApplication.id
+          containerName: 'data'
+        }
+      }
+      ```
+
+      To connect your container to the store, create a connection from the
+      Container resource to the store as shown below. This verification test is
+      provisioning-only because the stock demo image has no Azure Blob backend, but
+      the type still exposes a connection surface for applications that can use it.
+      ```
+      resource frontend 'Radius.Compute/containers@2025-08-01-preview' = {
+        name: 'frontend'
+        properties: {
+          application: myApplication.id
+          environment: environment
+          container: {
+            image: 'frontend:1.25'
+          }
+          connections: {
+            storage: {
+              source: store.id
+            }
+          }
+        }
+      }
+      ```
+
+      The connection automatically injects environment variables into the
+      container for all properties from the store. The environment variables are
+      named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>`. In this example the
+      connection name is `storage` so the environment variables will be:
+
+      - CONNECTION_STORAGE_CONTAINERNAME
+      - CONNECTION_STORAGE_ENDPOINT
+      - CONNECTION_STORAGE_CONNECTIONSTRING
+      - CONNECTION_STORAGE_ACCOUNTNAME
+
+      The schema is platform-neutral: the same developer-facing properties can be
+      backed by Azure Blob Storage, AWS S3, or a Kubernetes object-store recipe by
+      changing only the platform recipe's module source, parameters, and outputs.
+
+    apiVersions:
+      '2025-08-01-preview':
+        schema:
+          type: object
+          properties:
+            environment:
+              type: string
+              description: "(Required) The Radius Environment ID. Typically set by the rad CLI. Typically value should be `environment`."
+            application:
+              type: string
+              description: "(Optional) The Radius Application ID. `myApplication.id` for example."
+            containerName:
+              type: string
+              default: data
+              description: "(Optional) The object container (blob container / S3 bucket) name to create inside the storage account. Defaults to `data` if not provided."
+            endpoint:
+              type: string
+              description: The object storage endpoint used to connect to the store. Mapped from the recipe module's `primaryBlobEndpoint` output.
+              readOnly: true
+            connectionString:
+              type: string
+              description: The storage account connection string. Mapped from the recipe module's `primaryConnectionString` output.
+              readOnly: true
+            accountName:
+              type: string
+              description: The Azure Storage account name. Mapped from the recipe module's `name` output.
+              readOnly: true
+            accountKey:
+              type: string
+              description: The Azure Storage account access key. Mapped from the recipe module's `primaryAccessKey` output.
+              readOnly: true
+          required: [environment]

--- a/Storage/objectStorage/test/app.bicep
+++ b/Storage/objectStorage/test/app.bicep
@@ -1,0 +1,45 @@
+extension radius
+
+extension objectStorage
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'objectstorage-azure-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource store 'Radius.Storage/objectStorage@2025-08-01-preview' = {
+  name: 'store'
+  properties: {
+    environment: environment
+    application: app.id
+    containerName: 'data'
+  }
+}
+
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      demo: {
+        image: 'ghcr.io/radius-project/samples/demo:latest'
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+      }
+    }
+    connections: {
+      storage: {
+        source: store.id
+      }
+    }
+  }
+}

--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -21,6 +21,7 @@ Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map cont
 | `Radius.Data/mongoDatabases` | Bicep | Azure Verified Module — `avm/res/document-db/database-account` |
 | `Radius.Data/mySqlDatabases` | Bicep | Azure Verified Module — `avm/res/db-for-my-sql/flexible-server` |
 | `Radius.Data/redisCaches` | Bicep | Azure Verified Module — `avm/res/cache/redis-enterprise` |
+| `Radius.Storage/objectStorage` | Bicep | Azure Verified Module — `avm/res/storage/storage-account` |
 | `Radius.Compute/containers` | Bicep | `ghcr.io/radius-project/kube-recipes/containers` |
 
 ## Parameters

--- a/recipepack/azure/bicep-recipepack.bicep
+++ b/recipepack/azure/bicep-recipepack.bicep
@@ -247,6 +247,38 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
           connectionString: 'primaryConnectionString'
         }
       }
+      'Radius.Storage/objectStorage': {
+        kind: 'bicep'
+        source: 'mcr.microsoft.com/bicep/avm/res/storage/storage-account:0.32.1'
+        parameters: {
+          name: '{{context.resource.name}}'
+          kind: 'StorageV2'
+          skuName: 'Standard_LRS'
+          allowBlobPublicAccess: false
+          // The AVM storage-account module is secure-by-default: with no networkAcls
+          // it applies { bypass: 'AzureServices', defaultAction: 'Deny' }, which
+          // firewalls the blob data plane so connecting apps get 403
+          // AuthorizationFailure. Allow key-authenticated data-plane access; data
+          // stays private (allowBlobPublicAccess is false and access needs the key).
+          networkAcls: {
+            bypass: 'AzureServices'
+            defaultAction: 'Allow'
+          }
+          blobServices: {
+            containers: [
+              {
+                name: '{{context.resource.properties.containerName}}'
+              }
+            ]
+          }
+          enableTelemetry: false
+        }
+        outputs: {
+          endpoint: 'primaryBlobEndpoint'
+          accountKey: 'primaryAccessKey'
+          accountName: 'name'
+        }
+      }
       'Radius.Compute/containers': {
         kind: 'bicep'
         source: 'ghcr.io/radius-project/kube-recipes/containers:latest'


### PR DESCRIPTION
## Summary

Adds the **`Radius.Storage/objectStorage`** resource type and its **Azure Recipe Pack** entry, following the Recipe Pack model (mirrors #206). The recipe provisions an **Azure Storage account** via the AVM `res/storage/storage-account:0.32.1` direct module, creates the developer's object container, and maps the module outputs onto the resource's connection properties.

## Files

| File | Description |
| --- | --- |
| `Storage/objectStorage/objectStorage.yaml` | Resource type definition (`containerName`; read-only `endpoint`/`connectionString`/`accountName`/`accountKey`). |
| `Storage/objectStorage/README.md` | Type overview, properties, and Recipe Pack reference. |
| `Storage/objectStorage/test/app.bicep` | Example app: an `objectStorage` resource + a container connected to it. |
| `recipepack/azure/bicep-recipepack.bicep` | Adds the `Radius.Storage/objectStorage` entry to the consolidated Azure Recipe Pack. |
| `recipepack/azure/README.md` | Adds the `objectStorage` row to the pack's recipe table. |

## Design notes

- **No injected secret.** Unlike database types, `objectStorage` needs no credential. Azure Storage generates its own account keys; the recipe maps `primaryAccessKey` onto the read-only `accountKey` property.
- **`networkAcls.defaultAction: Allow`.** The AVM storage-account module is secure-by-default: when `networkAcls` is not supplied it applies `{ bypass: 'AzureServices', defaultAction: 'Deny' }`, which firewalls the blob **data plane** — a connecting app gets `403 AuthorizationFailure`. Setting `defaultAction: Allow` lets the app reach blob storage. Data stays private: `allowBlobPublicAccess` is `false` and access still requires the account key.
- **Container creation.** The developer's `containerName` (default `data`) is created inside the account via `{{context.resource.properties.containerName}}`.
- **Output mapping.** `endpoint <- primaryBlobEndpoint`, `accountName <- name`, `accountKey <- primaryAccessKey`.
- **Platform-neutral schema.** The same properties can be backed by AWS S3 (Terraform) or a Kubernetes MinIO recipe by changing only the recipe's module source, parameters, and outputs.

## Verification

The type + recipe were verified end-to-end against a **real Azure Storage account** using the direct-module feature: provisioning succeeded, outputs resolved onto the resource, and a containerized app wrote through to Azure Blob storage (upload + list round-trip confirmed the object landed).
