### PR TITLE
Update mySqlDatabases recipes to read username/password directly

### DIFF
--- a/Data/mySqlDatabases/recipes/aws/terraform/main.tf
+++ b/Data/mySqlDatabases/recipes/aws/terraform/main.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.37.1"
-    }
   }
 }
 
@@ -21,7 +17,6 @@ locals {
   resource_name    = var.context.resource.name
   application_name = var.context.application != null ? var.context.application.name : ""
   environment_name = var.context.environment != null ? var.context.environment.name : ""
-  namespace        = var.context.runtime.kubernetes.namespace
 }
 
 //////////////////////////////////////////
@@ -29,10 +24,11 @@ locals {
 //////////////////////////////////////////
 
 locals {
-  port        = 3306
-  database    = try(var.context.resource.properties.database, "mysql_db")
-  secret_name = var.context.resource.properties.secretName
-  version     = try(var.context.resource.properties.version, "8.4")
+  port     = 3306
+  database = try(var.context.resource.properties.database, "mysql_db")
+  username = var.context.resource.properties.username
+  password = var.context.resource.properties.password
+  version  = try(var.context.resource.properties.version, "8.4")
 
   unique_suffix = substr(md5(local.resource_name), 0, 13)
 
@@ -46,17 +42,6 @@ locals {
     "radapp.io/resource"    = local.resource_name
     "radapp.io/application" = local.application_name
     "radapp.io/environment" = local.environment_name
-  }
-}
-
-//////////////////////////////////////////
-// Credentials
-//////////////////////////////////////////
-
-data "kubernetes_secret" "db_credentials" {
-  metadata {
-    name      = local.secret_name
-    namespace = local.namespace
   }
 }
 
@@ -108,8 +93,8 @@ module "db" {
   instance_class       = var.instanceClass
 
   db_name  = local.sanitized_database
-  username = try(data.kubernetes_secret.db_credentials.data["USERNAME"], "")
-  password = try(data.kubernetes_secret.db_credentials.data["PASSWORD"], "")
+  username = local.username
+  password = local.password
   port     = local.port
 
   allocated_storage = var.allocatedStorage

--- a/Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
+++ b/Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
@@ -20,7 +20,8 @@ var namespace = context.runtime.kubernetes.namespace
 // MySQL variables
 //////////////////////////////////////////
 
-var dbSecretName = context.resource.properties.secretName
+var username = context.resource.properties.username
+var password = context.resource.properties.password
 var database = context.resource.properties.?database ?? 'mysql_db'
 
 @description('The major MySQL server version in the X.Y format. Defaults to the version 8.4 if not provided.')
@@ -38,6 +39,28 @@ var labels = {
   'radapp.io/environment': environmentName
   'radapp.io/resource-type': replace(context.resource.type, '/', '-')
   'radapp.io/resource-group': resourceGroupName
+}
+
+//////////////////////////////////////////
+// MySQL credentials
+//
+// The administrator username and password are provided directly on the
+// Radius.Data/mySqlDatabases resource. `password` is x-radius-sensitive, so
+// Radius injects it into the Recipe decrypted. Store both in a Kubernetes
+// Secret so the MySQL container references them via secretKeyRef rather than
+// carrying the password inline in the Pod spec.
+//////////////////////////////////////////
+
+resource dbSecret 'core/Secret@v1' = {
+  metadata: {
+    name: '${resourceName}-credentials'
+    namespace: namespace
+    labels: labels
+  }
+  stringData: {
+    USERNAME: username
+    PASSWORD: password
+  }
 }
 
 //////////////////////////////////////////
@@ -80,7 +103,7 @@ resource mySql 'apps/Deployment@v1' = {
                 name: 'MYSQL_USER'
                 valueFrom: {
                   secretKeyRef: {
-                    name: dbSecretName
+                    name: dbSecret.metadata.name
                     key: 'USERNAME'
                   }
                 }
@@ -89,7 +112,7 @@ resource mySql 'apps/Deployment@v1' = {
                 name: 'MYSQL_PASSWORD'
                 valueFrom: {
                   secretKeyRef: {
-                    name: dbSecretName
+                    name: dbSecret.metadata.name
                     key: 'PASSWORD'
                   }
                 }
@@ -131,6 +154,7 @@ resource svc 'core/Service@v1' = {
 
 output result object = {
   resources: [
+    '/planes/kubernetes/local/namespaces/${dbSecret.metadata.namespace}/providers/core/Secret/${dbSecret.metadata.name}'
     '/planes/kubernetes/local/namespaces/${svc.metadata.namespace}/providers/core/Service/${svc.metadata.name}'
     '/planes/kubernetes/local/namespaces/${mySql.metadata.namespace}/providers/apps/Deployment/${mySql.metadata.name}'
   ]


### PR DESCRIPTION
## Description

The `Radius.Data/mySqlDatabases` resource type schema now takes the administrator `username` and `password` **directly on the resource** (with `password` marked `x-radius-sensitive`), replacing the previous `secretName` reference to a `Radius.Security/secrets` resource. The published recipes were never updated to match, so they still read `context.resource.properties.secretName` — meaning the schema and the recipes are inconsistent, and any deployment against the new schema fails (the recipe reads a now-removed property).

This PR updates both mySqlDatabases recipes to read `username`/`password` from the resource properties:

- **`recipes/kubernetes/bicep/kubernetes-mysql.bicep`**: creates a Kubernetes `Secret` from the provided `username`/`password` and references it via `secretKeyRef` (keeping the password out of the Pod spec inline), and tracks the Secret as an output resource.
- **`recipes/aws/terraform/main.tf`**: reads `username`/`password` from the resource properties and drops the `kubernetes_secret` data source and the now-unused `kubernetes` provider.

Once merged, the `mysqldatabases` recipe needs to be re-published to `ghcr.io/radius-project/kube-recipes/mysqldatabases:latest` (via the `Publish Bicep Recipes` workflow) so the live recipe matches the schema.

Related GitHub Issue: N/A

<!-- Unblocks radius-project/radius#12332, which updates the schema and the functional test bicep to the username/password shape. -->

## Testing

- `terraform fmt -check` and `terraform validate` pass for the AWS Terraform recipe.
- `bicep build` succeeds for the Kubernetes Bicep recipe; the compiled output wires `MYSQL_USER`/`MYSQL_PASSWORD` from the recipe-created Secret.
- End-to-end: after this recipe is published to `:latest`, the radius `Test_MySQLDatabase` functional test (which deploys a `mySqlDatabases` resource using `username`/`password`) provisions the MySQL Deployment/Service successfully.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [ ] Platform engineer documentation is in README.md
- [ ] Developer documentation is the top-level description property
- [ ] Example of defining the Resource Type is in the developer documentation
- [ ] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [ ] All properties in the Resource Type definition have clear descriptions
- [ ] Enum properties have values defined in `enum: []`
- [ ] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [ ] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [ ] Recipes include a results output variable with all read-only properties set
- [ ] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [ ] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [ ] Recipes are idempotent
- [x] Resource types and recipes were tested

<!--
Checklist items left unchecked are unchanged by this PR: it only updates the
mySqlDatabases recipes to match the already-merged schema. The schema, README,
and developer documentation were updated in the earlier schema PR (#200).
-->
