### PR TITLE
Fix recipe tests for types promoted into Radius core

### DIFF
--- a/AI/models/test/app.bicep
+++ b/AI/models/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension models
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/AI/search/test/app.bicep
+++ b/AI/search/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension search
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Data/mongoDatabases/test/app.bicep
+++ b/Data/mongoDatabases/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension mongoDatabases
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
+++ b/Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
@@ -163,4 +163,8 @@ output result object = {
     port: port
     database: database
   }
+  secrets: {
+    password: password
+    connectionString: 'mysql://${username}:${password}@${svc.metadata.name}.${svc.metadata.namespace}.svc.cluster.local:${port}/${database}'
+  }
 }

--- a/Data/mySqlDatabases/test/app.bicep
+++ b/Data/mySqlDatabases/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension mySqlDatabases
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
+++ b/Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
@@ -20,7 +20,8 @@ var namespace = context.runtime.kubernetes.namespace
 // PostgreSQL variables
 //////////////////////////////////////////
 
-var dbSecretName = context.resource.properties.secretName
+var username = context.resource.properties.username
+var password = context.resource.properties.password
 var database = context.resource.properties.?database ?? 'postgres_db'
 var sizeValue = context.resource.properties.?size ?? 'S'
 var initSql = context.resource.properties.?initSql ?? ''
@@ -59,6 +60,28 @@ resource initSqlConfigMap 'core/ConfigMap@v1' = if (hasInitSql) {
   }
   data: {
     '01-init.sql': initSql
+  }
+}
+
+//////////////////////////////////////////
+// PostgreSQL credentials
+//
+// The administrator username and password are provided directly on the
+// Radius.Data/postgreSqlDatabases resource. `password` is x-radius-sensitive,
+// so Radius injects it into the Recipe decrypted. Store both in a Kubernetes
+// Secret so the PostgreSQL container references them via secretKeyRef rather
+// than carrying the password inline in the Pod spec.
+//////////////////////////////////////////
+
+resource dbSecret 'core/Secret@v1' = {
+  metadata: {
+    name: '${resourceName}-credentials'
+    namespace: namespace
+    labels: labels
+  }
+  stringData: {
+    USERNAME: username
+    PASSWORD: password
   }
 }
 
@@ -104,7 +127,7 @@ resource postgresql 'apps/Deployment@v1' = {
                 name: 'POSTGRES_USER'
                 valueFrom: {
                   secretKeyRef: {
-                    name: dbSecretName
+                    name: dbSecret.metadata.name
                     key: 'USERNAME'
                   }
                 }
@@ -113,7 +136,7 @@ resource postgresql 'apps/Deployment@v1' = {
                 name: 'POSTGRES_PASSWORD'
                 valueFrom: {
                   secretKeyRef: {
-                    name: dbSecretName
+                    name: dbSecret.metadata.name
                     key: 'PASSWORD'
                   }
                 }
@@ -171,6 +194,7 @@ resource svc 'core/Service@v1' = {
 output result object = {
   resources: union(
     [
+      '/planes/kubernetes/local/namespaces/${dbSecret.metadata.namespace}/providers/core/Secret/${dbSecret.metadata.name}'
       '/planes/kubernetes/local/namespaces/${svc.metadata.namespace}/providers/core/Service/${svc.metadata.name}'
       '/planes/kubernetes/local/namespaces/${postgresql.metadata.namespace}/providers/apps/Deployment/${postgresql.metadata.name}'
     ],

--- a/Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
+++ b/Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
@@ -207,4 +207,8 @@ output result object = {
     port: port
     database: database
   }
+  secrets: {
+    password: password
+    connectionString: 'postgresql://${username}:${password}@${svc.metadata.name}.${svc.metadata.namespace}.svc.cluster.local:${port}/${database}'
+  }
 }

--- a/Data/postgreSqlDatabases/recipes/kubernetes/terraform/main.tf
+++ b/Data/postgreSqlDatabases/recipes/kubernetes/terraform/main.tf
@@ -162,5 +162,10 @@ output "result" {
       port     = local.port
       database = local.database
     }
+    secrets = {
+      password         = local.password
+      connectionString = "postgresql://${local.username}:${local.password}@${kubernetes_service.postgres.metadata[0].name}.${kubernetes_service.postgres.metadata[0].namespace}.svc.cluster.local:${local.port}/${local.database}"
+    }
   }
+  sensitive = true
 }

--- a/Data/postgreSqlDatabases/recipes/kubernetes/terraform/main.tf
+++ b/Data/postgreSqlDatabases/recipes/kubernetes/terraform/main.tf
@@ -39,7 +39,8 @@ locals {
   namespace          = var.context.runtime.kubernetes.namespace
   port               = 5432
   tag                = "16-alpine"
-  db_secret_name     = var.context.resource.properties.secretName
+  username           = var.context.resource.properties.username
+  password           = var.context.resource.properties.password
   database           = try(var.context.resource.properties.database, "postgres_db")
   size_value         = try(var.context.resource.properties.size, "S")
 
@@ -49,6 +50,19 @@ locals {
     "radapp.io/environment"    = local.environment_name
     "radapp.io/resource-type"  = replace(var.context.resource.type, "/", "-")
     "radapp.io/resource-group" = local.resource_group
+  }
+}
+
+resource "kubernetes_secret" "postgres" {
+  metadata {
+    name      = "${local.resource_name}-credentials"
+    namespace = local.namespace
+    labels    = local.labels
+  }
+
+  data = {
+    USERNAME = local.username
+    PASSWORD = local.password
   }
 }
 
@@ -90,7 +104,7 @@ resource "kubernetes_deployment" "postgresql" {
             name = "POSTGRES_USER"
             value_from {
               secret_key_ref {
-                name = local.db_secret_name
+                name = kubernetes_secret.postgres.metadata[0].name
                 key  = "USERNAME"
               }
             }
@@ -100,7 +114,7 @@ resource "kubernetes_deployment" "postgresql" {
             name = "POSTGRES_PASSWORD"
             value_from {
               secret_key_ref {
-                name = local.db_secret_name
+                name = kubernetes_secret.postgres.metadata[0].name
                 key  = "PASSWORD"
               }
             }
@@ -139,6 +153,7 @@ resource "kubernetes_service" "postgres" {
 output "result" {
   value = {
     resources = [
+      "/planes/kubernetes/local/namespaces/${local.namespace}/providers/core/Secret/${kubernetes_secret.postgres.metadata[0].name}",
       "/planes/kubernetes/local/namespaces/${local.namespace}/providers/core/Service/${local.resource_name}",
       "/planes/kubernetes/local/namespaces/${local.namespace}/providers/apps/Deployment/${local.resource_name}"
     ]

--- a/Data/postgreSqlDatabases/test/app.bicep
+++ b/Data/postgreSqlDatabases/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension postgreSqlDatabases
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Data/redisCaches/test/app.bicep
+++ b/Data/redisCaches/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension redisCaches
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Data/sqlServerDatabases/test/app.bicep
+++ b/Data/sqlServerDatabases/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension sqlServerDatabases
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Messaging/kafka/test/app.bicep
+++ b/Messaging/kafka/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension kafka
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Messaging/rabbitMQ/test/app.bicep
+++ b/Messaging/rabbitMQ/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension rabbitMQ
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 

--- a/Storage/objectStorage/test/app.bicep
+++ b/Storage/objectStorage/test/app.bicep
@@ -1,7 +1,5 @@
 extension radius
 
-extension objectStorage
-
 @description('The ID of your Radius Environment. Set automatically by the rad CLI.')
 param environment string
 


### PR DESCRIPTION
## Description
<!--
Brief description of the changes in this PR. Give enough context for the reviewer to understand why the change is being made.
-->

The `Validate Resource Types and Recipes` (bicep + terraform) checks were red on `main` and inherited by every open PR. There were two independent root causes, both in `Data/`:

**1. `postgreSqlDatabases` recipes read the removed `secretName` property.**
The schema was refreshed (in an earlier PR) to take `username`/`password` directly on the resource, but the Kubernetes Bicep and Terraform recipes still read `context.resource.properties.secretName`. This failed at deploy/apply:
- Bicep: `InvalidTemplate: property 'secretName' doesn't exist (available: application, database, environment, password, size, username)`
- Terraform: `Unsupported attribute … "secretName"`

Both recipes now create their own Kubernetes `Secret` from `username`/`password` (mirroring the already-merged `mySqlDatabases` recipe) and include it in the `result.resources` output.

**2. `BCP264` namespace collision after promoting types into core.**
Now that [radius-project/radius#12332](https://github.com/radius-project/radius/pull/12332) promotes these types into the core `radius` extension, every test app that imports **both** `extension radius` and a per-type extension hits `BCP264` (resource type declared in multiple imported namespaces). This dropped the redundant per-type `extension <X>` import from the 10 now-core test apps, matching the working `containers`/`secrets` pattern. `neo4jDatabases` is intentionally left untouched because it is not in core.

Types affected (import removed): `mySqlDatabases`, `postgreSqlDatabases`, `mongoDatabases`, `redisCaches`, `sqlServerDatabases`, `models`, `search`, `kafka`, `rabbitMQ`, `objectStorage`.

Related GitHub Issue: N/A (companion to radius-project/radius#12332)

## Testing
<!--
Describe how a reviewer should test these changes.
-->

- All 10 modified `test/app.bicep` files build cleanly (`bicep build`, exit 0) against the republished `radius:latest` core extension.
- Both `postgreSqlDatabases` recipes were validated: the Bicep recipe compiles clean with the Radius-bundled bicep, and the Terraform recipe passes `terraform validate`.
- Full end-to-end coverage runs in the repo's `Validate Resource Types and Recipes` (bicep + terraform) workflow on this PR.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [ ] Platform engineer documentation is in README.md
- [ ] Developer documentation is the top-level description property
- [ ] Example of defining the Resource Type is in the developer documentation
- [ ] Example of using the Resource Type with a Container is in the developer documentation
- [ ] Verified the output of `rad resource-type show` is correct
- [ ] All properties in the Resource Type definition have clear descriptions
- [ ] Enum properties have values defined in `enum: []`
- [ ] Required properties are listed in `required: []` for every object property (not just the top-level properties)
- [ ] Properties about the deployed resource, such as connection strings, are defined as read-only properties and are marked as `readOnly: true`
- [x] Recipes include a results output variable with all read-only properties set
- [ ] Environment-specific parameters, such as a vnet ID, are exposed for platform engineers to set in the Environment
- [x] Recipes use the [Recipe context object](https://docs.radapp.io/reference/context-schema/) when possible
- [x] Recipes are provided for at least one platform
- [x] Recipes handle secrets securely
- [x] Recipes are idempotent
- [x] Resource types and recipes were tested