### PR TITLE
fix(containers): emit secret env vars before value env vars so $(VAR) interpolation resolves

### DIFF
--- a/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+++ b/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
@@ -133,23 +133,34 @@ var containerSpecs = reduce(containerItems, [], (acc, item) => concat(acc, [{
     // Add environment variables from container definition and connections
     // Connection environment variables are automatically added from output values
     (contains(item.value, 'env') || length(connectionEnvVars) > 0) ? {
+      // Kubelet expands $(VAR) in an env var's value ONLY against env vars defined
+      // earlier in this container's ordered env list. Emit secret/valueFrom env vars
+      // FIRST so plain value env vars can compose them via $(VAR) without leaking
+      // plaintext through Radius state. (items() sorts by key, so a single mixed list
+      // would order secrets vs values by name only, which is not a real guarantee.)
       env: concat(
-        // Container-defined env vars
-        reduce(items(item.value.?env ?? {}), [], (envAcc, envItem) => concat(envAcc, [union(
-          {
-            name: envItem.key
-          },
-          contains(envItem.value, 'value') ? { value: envItem.value.value } : {},
-          (contains(envItem.value, 'valueFrom') && contains(envItem.value.valueFrom, 'secretKeyRef')) ? {
-            valueFrom: {
-              secretKeyRef: {
-                name: envItem.value.valueFrom.secretKeyRef.secretName
-                key: envItem.value.valueFrom.secretKeyRef.key
-              }
-            }
-          } : {}
-        )])),
-        // Connection-derived env vars (non-secrets connections)
+        // 1. Container-defined secret-backed (valueFrom.secretKeyRef) env vars.
+        reduce(items(item.value.?env ?? {}), [], (envAcc, envItem) =>
+          (contains(envItem.value, 'valueFrom') && contains(envItem.value.valueFrom, 'secretKeyRef'))
+            ? concat(envAcc, [{
+                name: envItem.key
+                valueFrom: {
+                  secretKeyRef: {
+                    name: envItem.value.valueFrom.secretKeyRef.secretName
+                    key: envItem.value.valueFrom.secretKeyRef.key
+                  }
+                }
+              }])
+            : envAcc),
+        // 2. Container-defined plain value env vars (may reference the secrets above).
+        reduce(items(item.value.?env ?? {}), [], (envAcc, envItem) =>
+          contains(envItem.value, 'value')
+            ? concat(envAcc, [{
+                name: envItem.key
+                value: envItem.value.value
+              }])
+            : envAcc),
+        // 3. Connection-derived env vars (non-secrets connections)
         connectionEnvVars
       )
     } : {},

--- a/Compute/containers/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containers/recipes/kubernetes/terraform/main.tf
@@ -347,16 +347,10 @@ resource "kubernetes_deployment" "deployment" {
               }
             }
 
-            # Environment variables with direct values
-            dynamic "env" {
-              for_each = [for e in init_container.value.env : e if e.value != null]
-              content {
-                name  = env.value.name
-                value = env.value.value
-              }
-            }
-
-            # Environment variables with secretKeyRef
+            # Environment variables with secretKeyRef.
+            # Emitted BEFORE plain-value env vars: kubelet only expands $(VAR) references
+            # against env vars defined earlier in the container's ordered env list, so
+            # secret-backed vars must precede any value vars that interpolate them.
             dynamic "env" {
               for_each = [for e in init_container.value.env : e if e.value == null && try(e.value_from.secret_key_ref, null) != null]
               content {
@@ -367,6 +361,16 @@ resource "kubernetes_deployment" "deployment" {
                     key  = env.value.value_from.secret_key_ref.key
                   }
                 }
+              }
+            }
+
+            # Environment variables with direct values (may reference the secret-backed
+            # vars above via $(VAR)); rendered after them so interpolation resolves.
+            dynamic "env" {
+              for_each = [for e in init_container.value.env : e if e.value != null]
+              content {
+                name  = env.value.name
+                value = env.value.value
               }
             }
 
@@ -423,16 +427,10 @@ resource "kubernetes_deployment" "deployment" {
               }
             }
 
-            # Environment variables with direct values
-            dynamic "env" {
-              for_each = [for e in container.value.env : e if e.value != null]
-              content {
-                name  = env.value.name
-                value = env.value.value
-              }
-            }
-
-            # Environment variables with secretKeyRef
+            # Environment variables with secretKeyRef.
+            # Emitted BEFORE plain-value env vars: kubelet only expands $(VAR) references
+            # against env vars defined earlier in the container's ordered env list, so
+            # secret-backed vars must precede any value vars that interpolate them.
             dynamic "env" {
               for_each = [for e in container.value.env : e if e.value == null && try(e.value_from.secret_key_ref, null) != null]
               content {
@@ -443,6 +441,16 @@ resource "kubernetes_deployment" "deployment" {
                     key  = env.value.value_from.secret_key_ref.key
                   }
                 }
+              }
+            }
+
+            # Environment variables with direct values (may reference the secret-backed
+            # vars above via $(VAR)); rendered after them so interpolation resolves.
+            dynamic "env" {
+              for_each = [for e in container.value.env : e if e.value != null]
+              content {
+                name  = env.value.name
+                value = env.value.value
               }
             }
 


### PR DESCRIPTION
## Description

Kubernetes kubelet expands `$(VAR)` in a container env var's `value` **only against env vars defined earlier in that same container's ordered env list** (plus service env vars). A forward/unresolved reference is left as the **literal** string `$(VAR)` — a silent runtime failure. Developers rely on this ordering to compose a secret into a larger string without ever surfacing the plaintext through Radius state, e.g.:

```bicep
env: {
  RAW_CONN: { valueFrom: { secretKeyRef: { secretName: kafka.properties.secret.name, key: 'connectionString' } } }
  SASL_JAAS_CONFIG: { value: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="$(RAW_CONN)";' }
}
```

For `$(RAW_CONN)` to resolve, the `RAW_CONN` (secret-backed) env var **must be emitted before** the `SASL_JAAS_CONFIG` (plain `value`) env var in the rendered Deployment. The required contract: **all `valueFrom`/secret-backed env vars come before all plain `value` env vars** in each container's env list.

Both Kubernetes container recipes violated this:

- **Terraform** (`recipes/kubernetes/terraform/main.tf`): each container rendered env via two `dynamic "env"` blocks with the **`value` block first** and the `value_from`/`secret_key_ref` block second — in **both** the `init_container` and the main `container` blocks. This is exactly backwards: a `value` containing `$(VAR)` was emitted before its secret var, so it could never resolve. A latent silent-failure bug.
- **Bicep** (`recipes/kubernetes/bicep/kubernetes-containers.bicep`): container-defined env was built by a single `reduce` producing one flat list that mixed `value` and `valueFrom` entries. Because Bicep `items()` sorts alphabetically by key, secret-vs-value ordering was an accident of env var **names**, not a guarantee.

### The fix (ordering only)

- **Terraform:** swapped the two `dynamic "env"` blocks in **both** the `init_container` and `container` blocks so the `value_from`/`secret_key_ref` block renders **first**, then the `value` block. Terraform concatenates same-named dynamic blocks in source order, so this deterministically puts secret-backed vars first. Filter predicates are unchanged; `local.connection_env_vars` are `value`-type and correctly land in the (now second) value block.
- **Bicep:** replaced the single container-env `reduce` with **two** reduces over the same `env` map — first only entries with `valueFrom.secretKeyRef`, then only entries with `value` — and `concat(secretEnvVars, valueEnvVars, connectionEnvVars)`. Per-entry shape is byte-identical to before.

No new schema fields; this is the ordering-only change. All other behavior (connections, `envFrom` secretRef injection, init containers, ports, volumes, resources, replicas, labels, probes) is preserved, and outputs are otherwise byte-identical for inputs that don't rely on ordering. Net effect: **secret/`valueFrom` vars first, then container `value` vars, then connection value vars**, enabling the two-env-var `$(VAR)` secret-composition pattern without leaking plaintext.

Related GitHub Issue: N/A

## Testing

Validated locally without a cluster:

- **Terraform** (`terraform` v1.14.3, in the recipe dir):
  - `terraform init -backend=false` → success
  - `terraform validate` → **Success** (the two `kubernetes_deployment` deprecation warnings are pre-existing and unrelated to this change)
  - `terraform plan` against a synthetic `context` proves type-based (not alphabetical) ordering. The value var (`AAA_SASL`) is deliberately named to sort **before** the secret var (`ZZZ_RAW_CONN`), yet the plan renders the secret first:
    ```
    + env {
        + name = "ZZZ_RAW_CONN"
        + value_from { secret_key_ref { name = "kafka-secret" ... } }
      }
    + env {
        + name  = "AAA_SASL"
        + value = "...$(ZZZ_RAW_CONN)..."
      }
    ```
  - Note: `terraform fmt -check` flags one **pre-existing** formatting nit in the `connection_env_vars` local (present on `main`, untouched here); left as-is to keep the diff scoped to the ordering fix. CI does not run `terraform fmt`/`validate`.
- **Bicep** (rad-bundled `~/.rad/bin/bicep` 0.42.1, which is what runs at deploy time): `bicep build` of the recipe compiles **cleanly** with no diagnostics (no `BCP318`/`BCP120`).

Not validated locally: end-to-end deploy on a live cluster (requires `make create-radius-cluster` + registry). The Bicep runtime ordering mirrors the Terraform behavior proven above.

## Contributor Checklist

- [x] File names follow naming conventions and folder structure
- [x] Recipes handle secrets securely (this change strengthens that — secret composition no longer requires surfacing plaintext through Radius state)
- [x] Recipes are idempotent (ordering-only change; unchanged)
- [x] Resource types and recipes were tested (terraform validate/plan + bicep build; see Testing)
- [ ] N/A — no Resource Type definition, README, or schema changes (recipe ordering fix only)