### PR TITLE
Skip null-valued connection properties in container env var injection

### DIFF
--- a/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+++ b/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
@@ -84,6 +84,9 @@ var secretNameEnvFrom = reduce(items(resourceConnections), [], (acc, conn) =>
 )
 
 // Each connection's resource properties (including the nested properties bag) become CONNECTION_<CONNECTION_NAME>_<PROPERTY_NAME>
+// Null-valued properties are skipped: sensitive properties (e.g. a database
+// password marked x-radius-sensitive) are redacted to null on reads, and
+// string(null) fails ARM template validation with "InvalidTemplate".
 var connectionEnvVars = reduce(items(resourceConnections), [], (acc, conn) => 
 // Only process non-secrets connections here (secrets use envFrom)
   !isSecretsResource[conn.key] && connectionDefinitions[conn.key].?disableDefaultEnvVars != true
@@ -91,7 +94,7 @@ var connectionEnvVars = reduce(items(resourceConnections), [], (acc, conn) =>
         acc,
         // Add top-level connection properties (excluding metadata and the nested properties bag)
         reduce(items(conn.value ?? {}), [], (envAcc, prop) => 
-          (prop.key == 'properties' || prop.key == 'secretName' || contains(excludedProperties, prop.key))
+          (prop.key == 'properties' || prop.key == 'secretName' || contains(excludedProperties, prop.key) || prop.value == null)
             ? envAcc 
             : concat(envAcc, [{
                 name: toUpper('CONNECTION_${conn.key}_${prop.key}')
@@ -100,7 +103,7 @@ var connectionEnvVars = reduce(items(resourceConnections), [], (acc, conn) =>
         ),
         // Flatten the nested connection.properties bag so values like host/port become their own env vars
         reduce(items(conn.value.?properties ?? {}), [], (envAcc, prop) => 
-          (prop.key == 'secretName' || contains(excludedProperties, prop.key))
+          (prop.key == 'secretName' || contains(excludedProperties, prop.key) || prop.value == null)
             ? envAcc 
             : concat(envAcc, [{
                 name: toUpper('CONNECTION_${conn.key}_${prop.key}')


### PR DESCRIPTION
## Summary

The kubernetes containers Bicep recipe builds `CONNECTION_<NAME>_<PROP>` environment variables by calling `string(prop.value)` for every property of a connected resource. When a property value is **null**, this fails ARM template validation and aborts the whole deployment:

```
{
  "code": "InvalidTemplate",
  "message": "Deployment template validation failed: 'The template variable 'connectionEnvVars' is not valid: The template language function 'string' expects its first parameter to be one of the following types 'Integer, String, Boolean, Object, Array'. The provided value is of type 'Null'. ...'."
}
```

### Repro

Any container that connects to a resource exposing a **sensitive** property hits this. For example `Radius.Data/mySqlDatabases` marks `password` as `x-radius-sensitive`, so Radius **redacts it to null on reads**. When a container has `connections: { mysqldb: { source: database.id } }`, the recipe reads the connection's properties, tries `string(null)` on the redacted `password`, and the deploy fails.

## Fix

Skip properties whose value is `null` in both the top-level and nested-`properties` reduces of `connectionEnvVars`, alongside the existing guards for `properties` / `secretName` / `excludedProperties` keys.

## Notes

- The Terraform sibling recipe (`recipes/kubernetes/terraform/main.tf`) already guards these values with `can(tostring(...))` and is unaffected.
- This is separate from #… (the recent env-var ordering change), which only reordered *container-defined* env vars and did not touch the *connection-derived* path.
