### PR TITLE
Adopt the recipe secret-output pattern for secret-bearing resource types

### DIFF
--- a/AI/models/README.md
+++ b/AI/models/README.md
@@ -14,7 +14,7 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `application` | string | Optional | The Radius Application ID. |
 | `model` | string | Optional | The model deployment to provision. Defaults to `gpt-5-mini`. |
 | `endpoint` | string | Read only | The base URL used to call the model inference endpoint. Set from the Recipe module's output. |
-| `apiKey` | string | Read only | The API key used to call the model inference endpoint. Set from the Recipe module's output. |
+| `secrets` | object | Read only | Recipe secrets. `secrets.name` references the managed `Radius.Security/secrets` resource; `secrets.apiKey` is the secret key (delivered via that managed secret, never stored on the resource). |
 
 ## Recipe Packs
 
@@ -26,4 +26,4 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 ## Using the resource type
 
-Add a `models` resource to your application and connect a container to it. Radius injects the model's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_LLM_MODEL`, `CONNECTION_LLM_ENDPOINT`, and `CONNECTION_LLM_APIKEY`). See [`test/app.bicep`](test/app.bicep) for a complete example.
+Add a `models` resource to your application and connect a container to it. Radius injects the model's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_LLM_MODEL` and `CONNECTION_LLM_ENDPOINT`). The `apiKey` secret is not injected — bind it from the managed `Radius.Security/secrets` resource with a container `secretKeyRef` using `model.properties.secrets.name`. See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/AI/models/models.yaml
+++ b/AI/models/models.yaml
@@ -46,7 +46,11 @@ types:
 
       - CONNECTION_LLM_MODEL
       - CONNECTION_LLM_ENDPOINT
-      - CONNECTION_LLM_APIKEY
+
+      The `apiKey` secret is NOT injected via the connection — it is materialized
+      into a managed `Radius.Security/secrets` resource. Bind it into a container
+      env var with a `secretKeyRef`, using `model.properties.secrets.name` as the
+      `secretName` and key `apiKey` (see the `secrets` property).
 
     apiVersions:
       '2025-08-01-preview':
@@ -67,8 +71,21 @@ types:
               type: string
               description: "(Read Only) The base URL used to call the model inference endpoint. Mapped from the recipe module's output."
               readOnly: true
-            apiKey:
-              type: string
-              description: "(Read Only) The API key used to call the model inference endpoint. Mapped from the recipe module's `primaryKey` output."
-              readOnly: true
+            secrets:
+              type: object
+              description: >-
+                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
+                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
+                the other sub-properties declare secret keys whose values are written only into that
+                managed secret (never onto this resource). Consumers bind a key into a container env var
+                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
+              properties:
+                name:
+                  type: string
+                  readOnly: true
+                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
+                apiKey:
+                  type: string
+                  readOnly: true
+                  description: "(Read Only) The API key used to call the model inference endpoint. Mapped from the recipe module's `primaryKey` output; delivered via the managed secret."
           required: [environment]

--- a/AI/models/test/app.bicep
+++ b/AI/models/test/app.bicep
@@ -27,6 +27,19 @@ resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
+        // The recipe's secret output(s) are materialized into a managed
+        // Radius.Security/secrets resource and consumed here BY REFERENCE via
+        // secretKeyRef — the value never lands on model state.
+        env: {
+          MODEL_APIKEY: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: model.properties.secrets.name
+                key: 'apiKey'
+              }
+            }
+          }
+        }
         ports: {
           web: {
             containerPort: 3000

--- a/AI/search/README.md
+++ b/AI/search/README.md
@@ -13,7 +13,7 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `environment` | string | Required | The Radius Environment ID. Typically set by the `rad` CLI. |
 | `application` | string | Optional | The Radius Application ID. |
 | `endpoint` | string | Read only | The endpoint used to connect to the search service. Set from the Recipe module's output. |
-| `apiKey` | string | Read only | The admin API key used to connect to the search service. Set from the Recipe module's output. |
+| `secrets` | object | Read only | Recipe secrets. `secrets.name` references the managed `Radius.Security/secrets` resource; `secrets.apiKey` is the secret key (delivered via that managed secret, never stored on the resource). |
 
 ## Recipe Packs
 
@@ -25,4 +25,4 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 ## Using the resource type
 
-Add a `search` resource to your application and connect a container to it. Radius injects the search service's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_SEARCH_ENDPOINT` and `CONNECTION_SEARCH_APIKEY`). See [`test/app.bicep`](test/app.bicep) for a complete example.
+Add a `search` resource to your application and connect a container to it. Radius injects the search service's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_SEARCH_ENDPOINT`). The `apiKey` secret is not injected — bind it from the managed `Radius.Security/secrets` resource with a container `secretKeyRef` using `search.properties.secrets.name`. See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/AI/search/search.yaml
+++ b/AI/search/search.yaml
@@ -46,7 +46,11 @@ types:
       example the connection name is `search` so the environment variables will be:
 
       - CONNECTION_SEARCH_ENDPOINT
-      - CONNECTION_SEARCH_APIKEY
+
+      The `apiKey` secret is NOT injected via the connection — it is materialized
+      into a managed `Radius.Security/secrets` resource. Bind it into a container
+      env var with a `secretKeyRef`, using `search.properties.secrets.name` as the
+      `secretName` and key `apiKey` (see the `secrets` property).
 
     apiVersions:
       '2025-08-01-preview':
@@ -63,8 +67,21 @@ types:
               type: string
               description: The endpoint used to connect to the search service. Mapped from the recipe module's output.
               readOnly: true
-            apiKey:
-              type: string
-              description: The admin API key used to connect to the search service. Mapped from the recipe module's output.
-              readOnly: true
+            secrets:
+              type: object
+              description: >-
+                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
+                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
+                the other sub-properties declare secret keys whose values are written only into that
+                managed secret (never onto this resource). Consumers bind a key into a container env var
+                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
+              properties:
+                name:
+                  type: string
+                  readOnly: true
+                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
+                apiKey:
+                  type: string
+                  readOnly: true
+                  description: The admin API key used to connect to the search service. Mapped from the recipe module's output; delivered via the managed secret.
           required: [environment]

--- a/AI/search/test/app.bicep
+++ b/AI/search/test/app.bicep
@@ -26,6 +26,19 @@ resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
+        // The recipe's secret output(s) are materialized into a managed
+        // Radius.Security/secrets resource and consumed here BY REFERENCE via
+        // secretKeyRef — the value never lands on searchService state.
+        env: {
+          SEARCH_APIKEY: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: searchService.properties.secrets.name
+                key: 'apiKey'
+              }
+            }
+          }
+        }
         ports: {
           web: {
             containerPort: 3000

--- a/Data/mongoDatabases/README.md
+++ b/Data/mongoDatabases/README.md
@@ -14,7 +14,7 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `application` | string | Optional | The Radius Application ID. |
 | `database` | string | Optional | The Mongo database name. Defaults to `mongo_db`. |
 | `endpoint` | string | Read only | The endpoint used to connect to the database. Set from the Recipe module's output. |
-| `connectionString` | string | Read only | The connection string used to connect to the database. Set from the Recipe module's output. |
+| `secrets` | object | Read only | Recipe secrets. `secrets.name` references the managed `Radius.Security/secrets` resource; `secrets.connectionString` is the secret key (delivered via that managed secret, never stored on the resource). |
 
 ## Recipe Packs
 
@@ -26,4 +26,4 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 ## Using the resource type
 
-Add a `mongoDatabases` resource to your application and connect a container to it. Radius injects the database's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_MONGODB_DATABASE`, `CONNECTION_MONGODB_ENDPOINT`, and `CONNECTION_MONGODB_CONNECTIONSTRING`). See [`test/app.bicep`](test/app.bicep) for a complete example.
+Add a `mongoDatabases` resource to your application and connect a container to it. Radius injects the database's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_MONGODB_DATABASE` and `CONNECTION_MONGODB_ENDPOINT`). The `connectionString` secret is not injected — bind it from the managed `Radius.Security/secrets` resource with a container `secretKeyRef` using `mongo.properties.secrets.name`. See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Data/mongoDatabases/mongoDatabases.yaml
+++ b/Data/mongoDatabases/mongoDatabases.yaml
@@ -45,7 +45,11 @@ types:
 
       - CONNECTION_MONGO_DATABASE
       - CONNECTION_MONGO_ENDPOINT
-      - CONNECTION_MONGO_CONNECTIONSTRING
+
+      The `connectionString` secret is NOT injected via the connection — it is
+      materialized into a managed `Radius.Security/secrets` resource. Bind it into
+      a container env var with a `secretKeyRef`, using `mongo.properties.secrets.name`
+      as the `secretName` and key `connectionString` (see the `secrets` property).
 
       Portability note: this schema is platform-neutral so the same resource
       type works with Azure AVM, AWS Terraform modules, and Kubernetes recipes.
@@ -71,8 +75,21 @@ types:
               type: string
               description: The endpoint used to connect to the database. Mapped from the recipe module's output.
               readOnly: true
-            connectionString:
-              type: string
-              description: The connection string used to connect to the database. Mapped from the recipe module's output.
-              readOnly: true
+            secrets:
+              type: object
+              description: >-
+                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
+                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
+                the other sub-properties declare secret keys whose values are written only into that
+                managed secret (never onto this resource). Consumers bind a key into a container env var
+                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
+              properties:
+                name:
+                  type: string
+                  readOnly: true
+                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
+                connectionString:
+                  type: string
+                  readOnly: true
+                  description: The connection string used to connect to the database. Mapped from the recipe module's output; delivered via the managed secret.
           required: [environment]

--- a/Data/mongoDatabases/test/app.bicep
+++ b/Data/mongoDatabases/test/app.bicep
@@ -29,6 +29,19 @@ resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
+        // The recipe's secret output(s) are materialized into a managed
+        // Radius.Security/secrets resource and consumed here BY REFERENCE via
+        // secretKeyRef — the value never lands on mongo state.
+        env: {
+          MONGODB_CONNECTIONSTRING: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: mongo.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+        }
         ports: {
           web: {
             containerPort: 3000

--- a/Data/redisCaches/README.md
+++ b/Data/redisCaches/README.md
@@ -15,7 +15,7 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `size` | string (`S`, `M`, `L`) | Optional | The size of the Redis cache. Defaults to `S`. The Recipe maps the size onto a concrete cloud SKU. |
 | `host` | string | Read only | The host name used to connect to the cache. Set from the Recipe module's output. |
 | `port` | integer | Read only | The TLS port number used to connect to the cache. Set from the Recipe module's output. |
-| `url` | string | Read only | The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`), including the access key. Set from the Recipe module's output. |
+| `secrets` | object | Read only | Recipe secrets. `secrets.name` references the managed `Radius.Security/secrets` resource; `secrets.url` is the secret key (delivered via that managed secret, never stored on the resource). |
 
 ## Recipe Packs
 
@@ -27,4 +27,4 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 ## Using the resource type
 
-Add a `redisCaches` resource to your application and connect a container to it. Radius injects the cache's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_REDIS_HOST`, `CONNECTION_REDIS_PORT`, and `CONNECTION_REDIS_URL`). See [`test/app.bicep`](test/app.bicep) for a complete example.
+Add a `redisCaches` resource to your application and connect a container to it. Radius injects the cache's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_REDIS_HOST` and `CONNECTION_REDIS_PORT`). The `url` secret is not injected — bind it from the managed `Radius.Security/secrets` resource with a container `secretKeyRef` using `redis.properties.secrets.name`. See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Data/redisCaches/redisCaches.yaml
+++ b/Data/redisCaches/redisCaches.yaml
@@ -47,7 +47,11 @@ types:
 
       - CONNECTION_REDIS_HOST
       - CONNECTION_REDIS_PORT
-      - CONNECTION_REDIS_URL
+
+      The `url` secret is NOT injected via the connection — it is materialized into
+      a managed `Radius.Security/secrets` resource. Bind it into a container env var
+      with a `secretKeyRef`, using `redis.properties.secrets.name` as the `secretName`
+      and key `url` (see the `secrets` property).
 
     apiVersions:
       '2025-08-01-preview':
@@ -72,9 +76,21 @@ types:
               type: integer
               description: "(Read Only) The TLS port number used to connect to the cache. Mapped from the recipe module's `port` output (Azure Managed Redis uses 10000)."
               readOnly: true
-            url:
-              type: string
-              description: "(Read Only) The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output."
-              x-radius-sensitive: true
-              readOnly: true
+            secrets:
+              type: object
+              description: >-
+                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
+                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
+                the other sub-properties declare secret keys whose values are written only into that
+                managed secret (never onto this resource). Consumers bind a key into a container env var
+                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
+              properties:
+                name:
+                  type: string
+                  readOnly: true
+                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
+                url:
+                  type: string
+                  readOnly: true
+                  description: "(Read Only) The full TLS connection URL (`rediss://:<access-key>@<host>:<port>`) used to connect to the cache, including the access key. Mapped from the recipe module's `primaryConnectionString` output; delivered via the managed secret."
           required: [environment]

--- a/Data/redisCaches/test/app.bicep
+++ b/Data/redisCaches/test/app.bicep
@@ -27,6 +27,19 @@ resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
+        // The recipe's secret output(s) are materialized into a managed
+        // Radius.Security/secrets resource and consumed here BY REFERENCE via
+        // secretKeyRef — the value never lands on redis state.
+        env: {
+          REDIS_URL: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: redis.properties.secrets.name
+                key: 'url'
+              }
+            }
+          }
+        }
         ports: {
           web: {
             containerPort: 3000

--- a/Messaging/kafka/README.md
+++ b/Messaging/kafka/README.md
@@ -14,7 +14,7 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `application` | string | Optional | The Radius Application ID. |
 | `topic` | string | Optional | The Kafka topic/Event Hub name to create. Defaults to `events`. |
 | `host` | string | Read only | The host name used to connect to the Kafka-compatible endpoint. Set from the Recipe module's output. |
-| `connectionString` | string | Read only | The connection string used to connect to the Kafka-compatible endpoint. Set from the Recipe module's output. |
+| `secrets` | object | Read only | Recipe secrets. `secrets.name` references the managed `Radius.Security/secrets` resource; `secrets.connectionString` is the secret key (delivered via that managed secret, never stored on the resource). |
 
 ## Recipe Packs
 
@@ -26,4 +26,4 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 ## Using the resource type
 
-Add a `kafka` resource to your application and connect a container to it. Radius injects the Kafka connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_KAFKA_HOST` and `CONNECTION_KAFKA_CONNECTIONSTRING`). See [`test/app.bicep`](test/app.bicep) for a complete example.
+Add a `kafka` resource to your application and connect a container to it. Radius injects the Kafka connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_KAFKA_HOST`). The `connectionString` secret is not injected — bind it from the managed `Radius.Security/secrets` resource with a container `secretKeyRef` using `kafka.properties.secrets.name`. See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Messaging/kafka/kafka.yaml
+++ b/Messaging/kafka/kafka.yaml
@@ -43,7 +43,11 @@ types:
       connection name is `kafka` so the environment variables will be:
 
       - CONNECTION_KAFKA_HOST
-      - CONNECTION_KAFKA_CONNECTIONSTRING
+
+      The `connectionString` secret is NOT injected via the connection — it is
+      materialized into a managed `Radius.Security/secrets` resource. Bind it into
+      a container env var with a `secretKeyRef`, using `kafka.properties.secrets.name`
+      as the `secretName` and key `connectionString` (see the `secrets` property).
 
       Portability note: the schema is platform-neutral so the same type works
       with Azure AVM (Bicep), AWS Terraform registry modules, and Kubernetes
@@ -72,8 +76,21 @@ types:
               type: string
               description: The host name used to connect to the Kafka-compatible endpoint. For Azure Event Hubs this is the namespace name; the bootstrap server is `<host>.servicebus.windows.net:9093`.
               readOnly: true
-            connectionString:
-              type: string
-              description: The connection string used to connect to the Kafka-compatible endpoint. Mapped from the recipe module's output.
-              readOnly: true
+            secrets:
+              type: object
+              description: >-
+                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
+                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
+                the other sub-properties declare secret keys whose values are written only into that
+                managed secret (never onto this resource). Consumers bind a key into a container env var
+                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
+              properties:
+                name:
+                  type: string
+                  readOnly: true
+                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
+                connectionString:
+                  type: string
+                  readOnly: true
+                  description: The connection string used to connect to the Kafka-compatible endpoint. Mapped from the recipe module's `primaryConnectionString` output; delivered via the managed secret.
           required: [environment]

--- a/Messaging/kafka/test/app.bicep
+++ b/Messaging/kafka/test/app.bicep
@@ -27,6 +27,19 @@ resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
+        // The recipe's secret output(s) are materialized into a managed
+        // Radius.Security/secrets resource and consumed here BY REFERENCE via
+        // secretKeyRef — the value never lands on kafkaBroker state.
+        env: {
+          KAFKA_CONNECTIONSTRING: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: kafkaBroker.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+        }
         ports: {
           web: {
             containerPort: 3000

--- a/Messaging/rabbitMQ/README.md
+++ b/Messaging/rabbitMQ/README.md
@@ -16,7 +16,7 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `application` | string | Optional | The Radius Application ID. |
 | `queue` | string | Optional | The queue name to create. Defaults to `jobs`. |
 | `host` | string | Read only | The host or namespace name used to connect to the queue. Set from the Recipe module's output. |
-| `connectionString` | string | Read only | The primary connection string used to connect to the queue. Set from the Recipe module's output. |
+| `secrets` | object | Read only | Recipe secrets. `secrets.name` references the managed `Radius.Security/secrets` resource; `secrets.connectionString` is the secret key (delivered via that managed secret, never stored on the resource). |
 
 ## Recipe Packs
 
@@ -28,4 +28,4 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 ## Using the resource type
 
-Add a `rabbitMQ` resource to your application and connect a container to it. Radius injects the queue's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_RABBITMQ_HOST` and `CONNECTION_RABBITMQ_CONNECTIONSTRING`). See [`test/app.bicep`](test/app.bicep) for a complete example.
+Add a `rabbitMQ` resource to your application and connect a container to it. Radius injects the queue's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_RABBITMQ_HOST`). The `connectionString` secret is not injected — bind it from the managed `Radius.Security/secrets` resource with a container `secretKeyRef` using `rabbitmq.properties.secrets.name`. See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Messaging/rabbitMQ/rabbitMQ.yaml
+++ b/Messaging/rabbitMQ/rabbitMQ.yaml
@@ -29,7 +29,11 @@ types:
       For a connection named `rabbitmq`, the variables are:
 
       - CONNECTION_RABBITMQ_HOST
-      - CONNECTION_RABBITMQ_CONNECTIONSTRING
+
+      The `connectionString` secret is NOT injected via the connection — it is
+      materialized into a managed `Radius.Security/secrets` resource. Bind it into
+      a container env var with a `secretKeyRef`, using `rabbitmq.properties.secrets.name`
+      as the `secretName` and key `connectionString` (see the `secrets` property).
 
     apiVersions:
       '2025-08-01-preview':
@@ -50,8 +54,21 @@ types:
               type: string
               description: The host or namespace name used to connect to the queue. Mapped from the recipe module's output.
               readOnly: true
-            connectionString:
-              type: string
-              description: The primary connection string used to connect to the queue. Mapped from the recipe module's output.
-              readOnly: true
+            secrets:
+              type: object
+              description: >-
+                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
+                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
+                the other sub-properties declare secret keys whose values are written only into that
+                managed secret (never onto this resource). Consumers bind a key into a container env var
+                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
+              properties:
+                name:
+                  type: string
+                  readOnly: true
+                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
+                connectionString:
+                  type: string
+                  readOnly: true
+                  description: The primary connection string used to connect to the queue. Mapped from the recipe module's output; delivered via the managed secret.
           required: [environment]

--- a/Messaging/rabbitMQ/test/app.bicep
+++ b/Messaging/rabbitMQ/test/app.bicep
@@ -27,6 +27,19 @@ resource democontainer 'Radius.Compute/containers@2025-08-01-preview' = {
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
+        // The recipe's secret output(s) are materialized into a managed
+        // Radius.Security/secrets resource and consumed here BY REFERENCE via
+        // secretKeyRef — the value never lands on queue state.
+        env: {
+          RABBITMQ_CONNECTIONSTRING: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: queue.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+        }
         ports: {
           web: {
             containerPort: 3000

--- a/Storage/objectStorage/README.md
+++ b/Storage/objectStorage/README.md
@@ -14,9 +14,8 @@ Developer documentation is embedded in the resource type definition YAML file an
 | `application` | string | Optional | The Radius Application ID. |
 | `containerName` | string | Optional | The object container (blob container / S3 bucket) name to create inside the storage account. Defaults to `data`. |
 | `endpoint` | string | Read only | The object storage endpoint. Set from the Recipe module's `primaryBlobEndpoint` output. |
-| `connectionString` | string | Read only | The storage account connection string. Set from the Recipe module's `primaryConnectionString` output. |
+| `secrets` | object | Read only | Recipe secrets. `secrets.name` references the managed `Radius.Security/secrets` resource; `secrets.connectionString`, `secrets.accountKey` are the secret keys (delivered via that managed secret, never stored on the resource). |
 | `accountName` | string | Read only | The Azure Storage account name. Set from the Recipe module's `name` output. |
-| `accountKey` | string | Read only | The Azure Storage account access key. Set from the Recipe module's `primaryAccessKey` output. |
 
 The schema is platform-neutral: the same developer-facing properties can be backed by Azure Blob Storage, AWS S3, or a Kubernetes object-store recipe by changing only the platform recipe's module source, parameters, and outputs.
 
@@ -30,4 +29,4 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 ## Using the resource type
 
-Add an `objectStorage` resource to your application and connect a container to it. Radius injects the store's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_STORAGE_ENDPOINT`, `CONNECTION_STORAGE_ACCOUNTNAME`, and `CONNECTION_STORAGE_CONTAINERNAME`). See [`test/app.bicep`](test/app.bicep) for a complete example.
+Add an `objectStorage` resource to your application and connect a container to it. Radius injects the store's connection properties into the container as environment variables named `CONNECTION_<CONNECTION-NAME>_<PROPERTY-NAME>` (for example `CONNECTION_STORAGE_ENDPOINT`, `CONNECTION_STORAGE_ACCOUNTNAME`, and `CONNECTION_STORAGE_CONTAINERNAME`). The `connectionString` and `accountKey` secrets are not injected — bind them from the managed `Radius.Security/secrets` resource with a container `secretKeyRef` using `store.properties.secrets.name`. See [`test/app.bicep`](test/app.bicep) for a complete example.

--- a/Storage/objectStorage/objectStorage.yaml
+++ b/Storage/objectStorage/objectStorage.yaml
@@ -48,8 +48,13 @@ types:
 
       - CONNECTION_STORAGE_CONTAINERNAME
       - CONNECTION_STORAGE_ENDPOINT
-      - CONNECTION_STORAGE_CONNECTIONSTRING
       - CONNECTION_STORAGE_ACCOUNTNAME
+
+      The `connectionString` and `accountKey` secrets are NOT injected via the
+      connection — they are materialized into a managed `Radius.Security/secrets`
+      resource. Bind them into container env vars with a `secretKeyRef`, using
+      `store.properties.secrets.name` as the `secretName` and the desired key
+      (`connectionString` or `accountKey`; see the `secrets` property).
 
       The schema is platform-neutral: the same developer-facing properties can be
       backed by Azure Blob Storage, AWS S3, or a Kubernetes object-store recipe by
@@ -74,16 +79,29 @@ types:
               type: string
               description: The object storage endpoint used to connect to the store. Mapped from the recipe module's `primaryBlobEndpoint` output.
               readOnly: true
-            connectionString:
-              type: string
-              description: The storage account connection string. Mapped from the recipe module's `primaryConnectionString` output.
-              readOnly: true
             accountName:
               type: string
               description: The Azure Storage account name. Mapped from the recipe module's `name` output.
               readOnly: true
-            accountKey:
-              type: string
-              description: The Azure Storage account access key. Mapped from the recipe module's `primaryAccessKey` output.
-              readOnly: true
+            secrets:
+              type: object
+              description: >-
+                (Read-only) Recipe secrets. The reserved `name` sub-property references the managed
+                Radius.Security/secrets resource Radius materializes from the recipe's `outputs.secrets`;
+                the other sub-properties declare secret keys whose values are written only into that
+                managed secret (never onto this resource). Consumers bind a key into a container env var
+                via `secretKeyRef`, using `<resource>.properties.secrets.name` as `secretName`.
+              properties:
+                name:
+                  type: string
+                  readOnly: true
+                  description: (Reserved) Name of the managed Radius.Security/secrets resource. Use as `secretName` in a container `secretKeyRef`.
+                connectionString:
+                  type: string
+                  readOnly: true
+                  description: The storage account connection string. Mapped from the recipe module's `primaryConnectionString` output; delivered via the managed secret.
+                accountKey:
+                  type: string
+                  readOnly: true
+                  description: The Azure Storage account access key. Mapped from the recipe module's `primaryAccessKey` output; delivered via the managed secret.
           required: [environment]

--- a/Storage/objectStorage/test/app.bicep
+++ b/Storage/objectStorage/test/app.bicep
@@ -27,6 +27,27 @@ resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
     containers: {
       demo: {
         image: 'ghcr.io/radius-project/samples/demo:latest'
+        // The recipe's secret output(s) are materialized into a managed
+        // Radius.Security/secrets resource and consumed here BY REFERENCE via
+        // secretKeyRef — the value never lands on store state.
+        env: {
+          STORAGE_CONNECTIONSTRING: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: store.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+          STORAGE_ACCOUNTKEY: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: store.properties.secrets.name
+                key: 'accountKey'
+              }
+            }
+          }
+        }
         ports: {
           web: {
             containerPort: 3000

--- a/recipepack/azure/aks-recipepack.bicep
+++ b/recipepack/azure/aks-recipepack.bicep
@@ -45,7 +45,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         outputs: {
           host: 'hostName'
           port: 'port'
-          url: 'primaryConnectionString'
+          secrets: {
+            url: 'primaryConnectionString'
+          }
         }
       }
       'Radius.AI/models': {
@@ -76,7 +78,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         }
         outputs: {
           endpoint: 'endpoint'
-          apiKey: 'primaryKey'
+          secrets: {
+            apiKey: 'primaryKey'
+          }
         }
       }
       'Radius.AI/search': {
@@ -92,7 +96,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         }
         outputs: {
           endpoint: 'endpoint'
-          apiKey: 'primaryKey'
+          secrets: {
+            apiKey: 'primaryKey'
+          }
         }
       }
       'Radius.Data/mongoDatabases': {
@@ -116,7 +122,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         }
         outputs: {
           endpoint: 'endpoint'
-          connectionString: 'primaryReadWriteConnectionString'
+          secrets: {
+            connectionString: 'primaryReadWriteConnectionString'
+          }
         }
       }
       'Radius.Data/mySqlDatabases': {
@@ -242,7 +250,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         }
         outputs: {
           host: 'name'
-          connectionString: 'primaryConnectionString'
+          secrets: {
+            connectionString: 'primaryConnectionString'
+          }
         }
       }
       'Radius.Messaging/kafka': {
@@ -262,7 +272,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         }
         outputs: {
           host: 'name'
-          connectionString: 'primaryConnectionString'
+          secrets: {
+            connectionString: 'primaryConnectionString'
+          }
         }
       }
       'Radius.Storage/objectStorage': {
@@ -293,8 +305,11 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         }
         outputs: {
           endpoint: 'primaryBlobEndpoint'
-          accountKey: 'primaryAccessKey'
           accountName: 'name'
+          secrets: {
+            accountKey: 'primaryAccessKey'
+            connectionString: 'primaryConnectionString'
+          }
         }
       }
       'Radius.Compute/containers': {


### PR DESCRIPTION
## Summary

Adopts the recipe **secret-output** pattern for the seven secret-bearing resource types, so their recipe-generated secrets are no longer stored on the owning resource.

Today these types expose their secret (connection string / URL / API key / account key) as a **plain read-only property**, which is written onto the resource and surfaced on reads, in logs, and in the application graph. This PR moves each secret into a managed `Radius.Security/secrets` resource and exposes only a read-only reference on the owner.

## What changed (per type)

For **kafka, rabbitMQ, mongoDatabases, redisCaches, models, search, objectStorage**:

- **Type schema (`<type>.yaml`)** — replace the plain secret property with a single read-only `secrets` block: a reserved `name` sub-property (the reference to the managed secret) plus the secret key(s). The block is intentionally **not** marked `readOnly` (forward-compat for future secret *inputs*); each sub-property's own `readOnly` flag is the output/input discriminator. Descriptions updated to consume the secret via `secretKeyRef`.
- **Recipe pack (`recipepack/azure/aks-recipepack.bicep`)** — nest the secret module outputs under `outputs.secrets`. Also adds the `objectStorage` `connectionString` mapping (declared on the type but previously missing from the pack).
- **`test/app.bicep`** — bind the secret into a container env var via `valueFrom.secretKeyRef` using `<resource>.properties.secrets.name`.
- **README** — reflect the `secrets` reference + `secretKeyRef` consumption.

| Type | Secret key(s) | Non-secret (still connection-injected) |
|---|---|---|
| Messaging/kafka | `connectionString` | `host` |
| Messaging/rabbitMQ | `connectionString` | `host` |
| Data/mongoDatabases | `connectionString` | `endpoint` |
| Data/redisCaches | `url` | `host`, `port` |
| AI/models | `apiKey` | `endpoint` |
| AI/search | `apiKey` | `endpoint` |
| Storage/objectStorage | `connectionString`, `accountKey` | `endpoint`, `accountName` |

## Decisions

- **Secret key names preserved** — redis keeps `url`, storage keeps `accountKey`. This is a secret-handling *mechanism* change, not a rename, so existing consumers of the key names are unaffected (the value now arrives via the managed secret instead of a resource property).
- **SQL types out of scope** — `mySqlDatabases`, `postgreSqlDatabases`, `sqlServerDatabases` use secret *inputs*, not outputs, and are unchanged.
- **Testing/CI stays in `resource-types-verification`** — this PR only updates the type definitions, recipe pack, and `test/app.bicep`; no CI workflows are moved here.

## Dependency

Requires the engine support in **radius-project/radius#12344** (fold the secret reference into the `secrets` block as `secrets.name`; read recipe secret mappings from nested `outputs.secrets`). The `validate-resource-types` CI runs against `rad edge`, so it will not go green until #12344 is merged and released to `edge`. The same pattern is validated end-to-end on real Azure across all seven types in `resource-types-verification` (7 base + 7 app workflows green).

Kept as a **draft** pending the engine release.
