### PR TITLE
Fix containerImages recipe crash on destroy when registry secret is gone

### DIFF
--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -127,8 +127,15 @@ data "kubernetes_secret" "registry_creds" {
 locals {
   # kubernetes_secret data source returns already-decoded values
   # (the provider decodes the base64 from the K8s API).
-  registry_username = local.use_auth ? data.kubernetes_secret.registry_creds[0].data["username"] : ""
-  registry_password = local.use_auth ? data.kubernetes_secret.registry_creds[0].data["password"] : ""
+  #
+  # try(..., "") guards against destroy-time evaluation: the Secret is
+  # owned by a separate Radius.Security/secrets resource, so on teardown
+  # it (or its namespace) may already be deleted while registrySecretName
+  # is still set. In that case the data source read resolves to a null
+  # .data map and indexing it crashes `terraform destroy`. The credentials
+  # are never used on destroy, so degrading to "" is safe.
+  registry_username = local.use_auth ? try(data.kubernetes_secret.registry_creds[0].data["username"], "") : ""
+  registry_password = local.use_auth ? try(data.kubernetes_secret.registry_creds[0].data["password"], "") : ""
 
   docker_config_json = local.use_auth ? jsonencode({
     auths = {

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -134,8 +134,12 @@ locals {
   # is still set. In that case the data source read resolves to a null
   # .data map and indexing it crashes `terraform destroy`. The credentials
   # are never used on destroy, so degrading to "" is safe.
-  registry_username = local.use_auth ? try(data.kubernetes_secret.registry_creds[0].data["username"], "") : ""
-  registry_password = local.use_auth ? try(data.kubernetes_secret.registry_creds[0].data["password"], "") : ""
+  registry_username = local.use_auth ? (
+    data.kubernetes_secret.registry_creds[0].data != null ? data.kubernetes_secret.registry_creds[0].data["username"] : ""
+  ) : ""
+  registry_password = local.use_auth ? (
+    data.kubernetes_secret.registry_creds[0].data != null ? data.kubernetes_secret.registry_creds[0].data["password"] : ""
+  ) : ""
 
   docker_config_json = local.use_auth ? jsonencode({
     auths = {

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -131,15 +131,12 @@ locals {
   # try(..., "") guards against destroy-time evaluation: the Secret is
   # owned by a separate Radius.Security/secrets resource, so on teardown
   # it (or its namespace) may already be deleted while registrySecretName
-  # is still set. In that case the data source read resolves to a null
-  # .data map and indexing it crashes `terraform destroy`. The credentials
-  # are never used on destroy, so degrading to "" is safe.
-  registry_username = local.use_auth ? (
-    data.kubernetes_secret.registry_creds[0].data != null ? data.kubernetes_secret.registry_creds[0].data["username"] : ""
-  ) : ""
-  registry_password = local.use_auth ? (
-    data.kubernetes_secret.registry_creds[0].data != null ? data.kubernetes_secret.registry_creds[0].data["password"] : ""
-  ) : ""
+  # is still set. In that case the data source read can resolve to a null
+  # .data map (or one missing these keys) and indexing it crashes
+  # `terraform destroy`. The credentials are never used on destroy, so
+  # degrading to "" is safe.
+  registry_username = try(data.kubernetes_secret.registry_creds[0].data["username"], "")
+  registry_password = try(data.kubernetes_secret.registry_creds[0].data["password"], "")
 
   docker_config_json = local.use_auth ? jsonencode({
     auths = {


### PR DESCRIPTION
## Description

The Kubernetes Terraform recipe for `Radius.Compute/containerImages` crashes on delete with:

```
Error: Attempt to index null value
  on .../Compute/containerImages/recipes/kubernetes/terraform/main.tf line 130, in locals:
 130: registry_username = local.use_auth ? data.kubernetes_secret.registry_creds[0].data["username"] : ""
This value is null, so it does not have any indices.
```

surfaced by Radius as `RecipeDeletionFailed: terraform destroy failure: exit status 1`.

### Root cause

The recipe reads registry credentials from a Kubernetes Secret via the `kubernetes_secret` data source and indexes `.data` unconditionally in `locals`:

```hcl
registry_username = local.use_auth ? data.kubernetes_secret.registry_creds[0].data["username"] : ""
registry_password = local.use_auth ? data.kubernetes_secret.registry_creds[0].data["password"] : ""
```

`use_auth` is `var.registrySecretName != ""`, which is still `true` on destroy — so `count = 1` and `registry_creds[0]` exists. But the recipe only *reads* the Secret; it is owned by a separate `Radius.Security/secrets` resource. On teardown there is no ordering guarantee that the Secret (or its namespace) outlives the `containerImages` resource, so the data source read resolves to a null `.data` map and indexing it aborts `terraform destroy`.

The credentials are never actually used during destroy (nothing builds/pushes an image on teardown), so the crash is purely from eagerly evaluating a value that is not needed.

### Fix

Wrap the index accesses in `try(..., "")` so they degrade to empty strings when the Secret is absent at destroy time. Create-time behavior is unchanged: when the Secret exists, the real values are read.

## Type of change

- This pull request fixes a bug in Radius.

## Testing

- `terraform fmt -check` passes.
- On create the Secret is present, so `try()` returns the real credential values (no behavior change).
- On destroy with the Secret already deleted, the locals now resolve to `""` instead of crashing, allowing the recipe to be deleted cleanly.