### PR TITLE
Update contributing-resource-types-recipes.md

### DIFF
--- a/docs/contributing/contributing-resource-types-recipes.md
+++ b/docs/contributing/contributing-resource-types-recipes.md
@@ -137,11 +137,12 @@ Each property must also include:
  - Whether the property is required or optional.
 
 When setting the description of properties:
- - Unquoted strings are preferred, avoid special characters such as `:`, `{`, `}`, `[`, `]`, `,`, `&`, `*`, `#`, `?`, `|`, `-`, `<`, `>`, `=`, `!`, `%`, `@`, and `\`.
- - Prefix the description with `(Required)`, `(Optional)`, or `(Read Only)`.
- - If an enum, do not add acceptable values in the description (these are visible in VS Code via Intellisense).
- - There are no defaults for enums. If the Recipes should assume a value, denote that "the value is assumed to be _____".
- - Denote values using `backquotes`. 
+ - **Prefix each description** with `(Required)`, `(Optional)`, or `(Read Only)` to match how the property is defined in the schema. Keep the prefix in sync with the schema's `required` array and `readOnly` flag.
+ - **Wrap literal values in backquotes**: enum members, defaults, property names, type names, and file names (for example `` `false` ``, `` `Radius.Core/environments` ``). Leave ordinary words unquoted.
+ - **State the default, if any**, at the end of the description as `` Defaults to `<value>` if not specified. `` This applies to all property types.
+ - **Don't restate the schema.** For enums, omit the list of accepted values; they surface through Intellisense in VS Code and in the resource type schema. Describe what the property does, not what values it accepts.
+ - **Keep descriptions unquoted.** Write property descriptions as plain, unquoted text. Do not use `:` or `#`. Ordinary punctuation such as commas, hyphens, parentheses, periods, and slashes are acceptable. If a description needs a colon or other special punctuation, use a `description: |` block.
+
 
 For example, the initial `redisCaches` Resource Type from above must be enhanced with developer documentation:
 

--- a/docs/contributing/contributing-resource-types-recipes.md
+++ b/docs/contributing/contributing-resource-types-recipes.md
@@ -138,9 +138,9 @@ Each property must also include:
 
 When setting the description of properties:
  - **Prefix each description** with `(Required)`, `(Optional)`, or `(Read Only)` to match how the property is defined in the schema. Keep the prefix in sync with the schema's `required` array and `readOnly` flag.
- - **Wrap literal values in backquotes**: enum members, defaults, property names, type names, and file names (for example `` `false` ``, `` `Radius.Core/environments` ``). Leave ordinary words unquoted.
+ - **Wrap literal values in backticks**: enum members, defaults, property names, type names, and file names (for example `` `false` ``, `` `Radius.Core/environments` ``). Leave ordinary words unquoted.
  - **State the default, if any**, at the end of the description as `` Defaults to `<value>` if not specified. `` This applies to all property types.
- - **Don't restate the schema.** For enums, omit the list of accepted values; they surface through Intellisense in VS Code and in the resource type schema. Describe what the property does, not what values it accepts.
+ - **Don't restate the schema.** For enums, omit the list of accepted values; they surface through IntelliSense in VS Code and in the resource type schema. Describe what the property does, not what values it accepts.
  - **Keep descriptions unquoted.** Write property descriptions as plain, unquoted text. Do not use `:` or `#`. Ordinary punctuation such as commas, hyphens, parentheses, periods, and slashes are acceptable. If a description needs a colon or other special punctuation, use a `description: |` block.
 
 


### PR DESCRIPTION
This pull request updates the documentation guidelines for describing resource type properties in `contributing-resource-types-recipes.md`. The main focus is on clarifying and standardizing how property descriptions should be written.

Documentation standards:

* Updated instructions to require prefixing each property description with `(Required)`, `(Optional)`, or `(Read Only)`, and to keep this in sync with the schema's `required` array and `readOnly` flag.
* Added guidance to wrap literal values (such as enum members, defaults, property names, type names, and file names) in backquotes, while leaving ordinary words unquoted.
* Specified that default values should be stated at the end of the description using the format: `` Defaults to `<value>` if not specified. ``
* Clarified that property descriptions should not restate the schema (e.g., do not list enum values) and should focus on what the property does.
* Emphasized that descriptions should be unquoted, avoid special characters like `:` or `#`, and use a `description: |` block if special punctuation is needed.Update the property description guidance in the contribution guide.
