### PR TITLE
fix(containerImages): restrict local build contexts

### DIFF
--- a/Compute/containerImages/README.md
+++ b/Compute/containerImages/README.md
@@ -72,7 +72,7 @@ A list of available Recipes for this Resource Type, including links to the Bicep
 
 Properties for the containerImages resource are provided to the Recipe via the [Recipe Context](https://docs.radapp.io/reference/context-schema/) object. These properties include:
 
-- `context.resource.properties.build.source` (string, required): The build context. Either a `git::https://...` URL or a local filesystem path to a directory containing the build context.
+- `context.resource.properties.build.source` (string, required): The build context. Either a `git::https://...` URL or a local filesystem path to a directory containing the build context under `/var/radius/build-contexts`.
 - `context.resource.properties.build.dockerfile` (string, optional): Path to the Dockerfile relative to the build context. Defaults to `Dockerfile`.
 - `context.resource.properties.build.platforms` (array of string, optional): Target platforms (e.g. `["linux/amd64", "linux/arm64"]`) for the multi-arch image. Defaults to `["linux/amd64", "linux/arm64"]`. Multi-arch builds require a cross-compile-friendly Dockerfile.
 - `context.resource.properties.build.args` (object, optional): Map of `--build-arg` values passed to the build.

--- a/Compute/containerImages/containerImages.yaml
+++ b/Compute/containerImages/containerImages.yaml
@@ -71,7 +71,7 @@ types:
               properties:
                 source:
                   type: string
-                  description: "(Required) Source location for the build. Either a git URL of the form `git::https://...` (BuildKit clones the repo inside the cluster) or a local filesystem path to a directory containing the build context. For git URLs, the subdirectory is selected via the go-getter `//<subdir>` segment and the ref via the `?ref=<branch-or-sha>` query parameter, in that order. Example, `git::https://github.com/myorg/myapp.git//frontend?ref=v1.2.3`."
+                  description: "(Required) Source location for the build. Either a git URL of the form `git::https://...` (BuildKit clones the repo inside the cluster) or a local filesystem path to a directory containing the build context under `/var/radius/build-contexts`. For git URLs, the subdirectory is selected via the go-getter `//<subdir>` segment and the ref via the `?ref=<branch-or-sha>` query parameter, in that order. Example, `git::https://github.com/myorg/myapp.git//frontend?ref=v1.2.3`."
                 dockerfile:
                   type: string
                   description: (Optional) Path to the Dockerfile relative to the build source. Defaults to `Dockerfile`.

--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -38,10 +38,11 @@ locals {
 
   image_name = local.resource_name
 
-  build_source  = local.properties.build.source
-  dockerfile    = try(local.properties.build.dockerfile, "Dockerfile")
-  platforms     = try(local.properties.build.platforms, ["linux/amd64", "linux/arm64"])
-  is_git_source = can(regex("^git::", local.build_source))
+  local_context_root = "/var/radius/build-contexts"
+  build_source       = local.properties.build.source
+  dockerfile         = try(local.properties.build.dockerfile, "Dockerfile")
+  platforms          = try(local.properties.build.platforms, ["linux/amd64", "linux/arm64"])
+  is_git_source      = can(regex("^git::", local.build_source))
 
   go_getter_stripped = local.is_git_source ? replace(local.build_source, "git::", "") : ""
   url_no_query       = local.is_git_source ? split("?", local.go_getter_stripped)[0] : ""
@@ -158,8 +159,12 @@ resource "terraform_data" "validate_inputs" {
       error_message = "containerImages: properties.build.dockerfile must be a relative path (no leading '/' and no '..' segments) matching [A-Za-z0-9._/-]+ (got ${local.dockerfile})."
     }
     precondition {
-      condition     = can(regex("^git::https://[A-Za-z0-9._:/@?=&%~+#-]+$", local.build_source)) || (!strcontains(local.build_source, "..") && can(regex("^[A-Za-z0-9._/+~-]+$", local.build_source)))
-      error_message = "containerImages: properties.build.source must be a git::https URL or a filesystem path (no '..' segments) (got ${local.build_source})."
+      condition = can(regex("^git::https://[A-Za-z0-9._:/@?=&%~+#-]+$", local.build_source)) || (
+        startswith(local.build_source, "${local.local_context_root}/") &&
+        !strcontains(local.build_source, "..") &&
+        can(regex("^[A-Za-z0-9._/+~-]+$", local.build_source))
+      )
+      error_message = "containerImages: properties.build.source must be a git::https URL or a filesystem path under ${local.local_context_root} (no '..' segments) (got ${local.build_source})."
     }
     precondition {
       condition     = length(local.platforms) > 0


### PR DESCRIPTION
## Summary

Restricts local container image build contexts to `/var/radius/build-contexts`. This prevents builds from accessing registry credentials in the Terraform working directory.

Git build sources are unchanged.

Fixes https://github.com/radius-project/resource-types-contrib/issues/231

## Question

@willdavsmith, should we address this, or is the current behavior acceptable? The issue only affects local builds, but a developer who controls the build context and Dockerfile can copy files available to `dynamic-rp`, including registry credentials.

**Pros:** Local builds can only access files the platform engineer places under `/var/radius/build-contexts`. Git builds are unchanged.

**Cons:** I think the Radius Helm chart cannot mount this directory through its values today. Local builds would require a custom chart or Deployment patch, plus a volume containing the source. Existing local paths outside this directory will stop working.