### PR TITLE
Disable Azure resource locks in AVM recipes to fix teardown

### DIFF
--- a/recipepack/azure/aks-recipepack.bicep
+++ b/recipepack/azure/aks-recipepack.bicep
@@ -41,6 +41,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
           }
           publicNetworkAccess: 'Enabled'
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           host: 'hostName'
@@ -75,6 +78,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
             }
           ]
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           endpoint: 'endpoint'
@@ -93,6 +99,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
           replicaCount: 1
           partitionCount: 1
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           endpoint: 'endpoint'
@@ -119,6 +128,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
             publicNetworkAccess: 'Enabled'
           }
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           endpoint: 'endpoint'
@@ -155,6 +167,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
             }
           ]
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           host: 'fqdn'
@@ -193,6 +208,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
           ]
           enableAdvancedThreatProtection: false
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           host: 'fqdn'
@@ -226,6 +244,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
             }
           ]
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           host: 'fullyQualifiedDomainName'
@@ -247,6 +268,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
             }
           ]
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           host: 'name'
@@ -269,6 +293,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
             }
           ]
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           host: 'name'
@@ -302,6 +329,9 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
             ]
           }
           enableTelemetry: false
+          lock: {
+            kind: 'None'
+          }
         }
         outputs: {
           endpoint: 'primaryBlobEndpoint'


### PR DESCRIPTION
## Problem

`recipepack/azure/aks-recipepack.bicep` maps data/messaging/storage resource types to **Azure Verified Modules (AVM)**. AVM `res/*` modules can emit a `Microsoft.Authorization/locks` resource (default lock name `lock-<name>`).

Radius/UCP does not have `Microsoft.Authorization/locks` registered as a manageable Azure resource type, so on environment/application **delete** it cannot resolve an API version for the lock and recipe deletion fails permanently:

```
RecipeDeletionFailed: failed to delete resource
".../flexibleServers/mysqldb-xxxx/providers/Microsoft.Authorization/locks/lock-mysqldb-xxxx":
could not find API version for type "Microsoft.Authorization/locks", type was not found
```

This blocks teardown of any environment that provisioned one of these resources (observed with `Radius.Data/mySqlDatabases`).

## Fix

Explicitly set `lock: { kind: 'None' }` on every AVM-backed Azure recipe so no management lock is ever created, guaranteeing clean deletion. Applied to all 10 AVM `res/*` recipes: redisCaches, AI/models, AI/search, mongoDatabases, mySqlDatabases, postgreSqlDatabases, sqlServerDatabases, rabbitMQ, kafka, objectStorage. The 4 Kubernetes kube-recipes are unaffected (no lock parameter).

## Validation

- `bicep build` before and after the change produces the identical set of pre-existing `secrets` type warnings (a `:latest` radius-types artifact) and **zero** new/lock-related errors.
- The change is additive and does not alter provisioning behavior — it only prevents lock creation.