### PR TITLE
Fix containerImages recipe failing when tag is left out

### DIFF
--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -159,7 +159,7 @@ resource "terraform_data" "validate_inputs" {
     }
     precondition {
       condition     = local.user_tag == null || can(regex("^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$", local.user_tag))
-      error_message = "containerImages: properties.tag must match Docker tag spec [A-Za-z0-9_][A-Za-z0-9._-]{0,127} (got ${local.user_tag})."
+      error_message = "containerImages: properties.tag must match Docker tag spec [A-Za-z0-9_][A-Za-z0-9._-]{0,127} (got ${jsonencode(local.user_tag)})."
     }
     precondition {
       condition     = !startswith(local.dockerfile, "/") && !strcontains(local.dockerfile, "..") && can(regex("^[A-Za-z0-9._/-]+$", local.dockerfile))


### PR DESCRIPTION
Fixes #209

**TL;DR:** The recipe crashes `terraform apply` when the optional `tag` is left out, because it puts a null tag into an error message. Wrapping it in `jsonencode()` fixes it. One line.

## The problem

`tag` is optional, and leaving it out is supposed to make the recipe build one from the image content, something like `sha256-<hash>`. Instead the apply dies before the build even starts.

The fault sits in a validation check. When the check fails it prints an error message with the tag spelled out, and a left-out tag arrives as null, which Terraform flatly refuses to splice into a string:

```
Error: Invalid template interpolation value
  154:  error_message = "... (got ${local.user_tag})."
The expression result is null. Cannot include a null value in a string template.
```

The catch is that the check was written to allow exactly this case. Its condition handles a null tag fine, but Terraform builds the error message even on the runs where the condition passes, and folding that null into the string blows up every time. The condition passes on a null, but the error message still gets built, and that's the step that fails.

## The fix

In `Compute/containerImages/recipes/kubernetes/terraform/main.tf`, the tag now goes through `jsonencode()` in the `validate_inputs` error message, which turns a null into the harmless text `null` instead of a crash.

I reached for `jsonencode` over `coalesce` because it does two useful things at once: it handles the null, and it wraps a genuinely bad tag in quotes, so a value like `"v 1"` reads clearly instead of trailing off into the sentence.

## Testing

- `terraform fmt -check` — clean.
- `terraform validate` — passes. The only warning is the old `kubernetes_secret` deprecation, which was there before.
- A resource with no `tag` now applies and builds with the `sha256-<hash>` tag.

One line moves. A valid tag behaves exactly as before, and the only thing that changes is that a missing tag stops taking the whole apply down with it.
