### PR TITLE
Fix containerImages recipe login against Docker Hub

### DIFF
--- a/Compute/containerImages/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containerImages/recipes/kubernetes/terraform/main.tf
@@ -36,6 +36,10 @@ locals {
   registry      = var.registry
   registry_host = split("/", var.registry)[0]
 
+  # Docker Hub auth must be keyed by https://index.docker.io/v1/, not the
+  # docker.io host (also covers index.docker.io / registry-1.docker.io).
+  docker_auth_key = contains(["docker.io", "index.docker.io", "registry-1.docker.io"], local.registry_host) ? "https://index.docker.io/v1/" : local.registry_host
+
   image_name = local.resource_name
 
   build_source  = local.properties.build.source
@@ -140,7 +144,7 @@ locals {
 
   docker_config_json = local.use_auth ? jsonencode({
     auths = {
-      (local.registry_host) = {
+      (local.docker_auth_key) = {
         auth = base64encode("${local.registry_username}:${local.registry_password}")
       }
     }


### PR DESCRIPTION
Fixes #253

**TL;DR:** Pushes to Docker Hub fail auth because the recipe keys the login by `docker.io` instead of `https://index.docker.io/v1/`. This keys it correctly for Docker Hub and leaves every other registry alone.

## The problem

Pushing to Docker Hub didn't work, and the whole reason was a single wrong key. The recipe wrote the registry login into `config.json` under `docker.io`, but Docker Hub only reads logins filed under its old URL, `https://index.docker.io/v1/`, so BuildKit came up empty and pushed as nobody. Back came `401 Unauthorized` / `denied`, on credentials that were perfectly good. The same slip catches the `index.docker.io` and `registry-1.docker.io` aliases too.

## The fix

In `Compute/containerImages/recipes/kubernetes/terraform/main.tf`, a new `docker_auth_key` local keys the login by `https://index.docker.io/v1/` when the registry host is one of Docker Hub's names (`docker.io`, `index.docker.io`, `registry-1.docker.io`), and by the host otherwise. The `config.json` auths map then uses that key instead of the raw host.

## What changes

- Other registries — `ghcr.io`, `ttl.sh`, ACR, ECR — are untouched, still keyed by host.
- Docker Hub — `docker.io/...` and its aliases — now logs in and pushes.
- Nothing changes when there's no Secret, and `docker_config_json` stays `""`.

## Testing

- `terraform fmt -check` — clean.
- `terraform validate` — passes. The only warning is the old `kubernetes_secret` deprecation, which was there before.
- I checked the rendered `config.json`: it keys the login by `https://index.docker.io/v1/` for `registry = docker.io/<user>`, and by the host for `registry = ghcr.io/<org>`.
