### PR TITLE
Switch the AKS containerImages recipe from Terraform to Bicep

### DIFF
--- a/recipepack/azure/README.md
+++ b/recipepack/azure/README.md
@@ -26,7 +26,7 @@ Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map cont
 | `Radius.Compute/persistentVolumes` | Bicep | `ghcr.io/radius-project/kube-recipes/persistentvolumes` |
 | `Radius.Security/secrets` | Bicep | `ghcr.io/radius-project/kube-recipes/secrets` |
 | `Radius.Compute/routes` | Bicep | `ghcr.io/radius-project/kube-recipes/routes` |
-| `Radius.Compute/containerImages` | Terraform | `git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform` |
+| `Radius.Compute/containerImages` | Bicep | `ghcr.io/radius-project/kube-recipes/containerimages` |
 
 ## Parameters
 

--- a/recipepack/azure/aks-recipepack.bicep
+++ b/recipepack/azure/aks-recipepack.bicep
@@ -363,8 +363,8 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         }
       }
       'Radius.Compute/containerImages': {
-        kind: 'terraform'
-        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform'
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/containerimages:latest'
         parameters: {
           registry: containerImagesRegistry
           registrySecretName: containerImagesRegistrySecretName


### PR DESCRIPTION
# Switch the AKS containerImages recipe from Terraform to Bicep

The AKS Azure recipe pack builds container images through the Terraform recipe for `Radius.Compute/containerImages`. It was left there on purpose: when the Bicep recipe landed in #251, no released Radius had the build hook that runs the recipe's `build.sh`. That hook has since shipped and the recipe is published, so the pack can move over.

## The change

In `recipepack/azure/aks-recipepack.bicep` the `Radius.Compute/containerImages` entry moves from `kind: 'terraform'` with a git source to `kind: 'bicep'` with `source: 'ghcr.io/radius-project/kube-recipes/containerimages:latest'`, keeping the `registry` and `registrySecretName` parameters. The `README.md` table row is updated to match. The new entry now looks like the other Bicep entries in the pack.