### PR TITLE
ci(release-namespace): rename to 'Release Namespace'

### DIFF
--- a/.github/workflows/release-namespace.yaml
+++ b/.github/workflows/release-namespace.yaml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
 ---
-name: release-namespace
+name: Release Namespace
 
 # Cuts an independent, per-namespace release of the resource-type manifests.
 #


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/release-namespace.yaml` workflow file, changing the workflow's display name to use title case for consistency.

Changed the `name` field from `release-namespace` to `Release Namespace` in `.github/workflows/release-namespace.yaml`.