### PR TITLE
ci(release): add support for recipe packs releases

### DIFF
--- a/.github/build/release.mk
+++ b/.github/build/release.mk
@@ -16,9 +16,11 @@
 
 ##@ Release
 
-# Per-namespace releases are cut by the release-namespace.yaml workflow. These
+# Per-namespace releases are cut by the release-namespace.yaml workflow and
+# per-recipe-pack releases by the release-recipe-pack.yaml workflow. These
 # targets mirror the workflow steps for local inspection and dry runs. Git tags
-# (Radius.<Category>/vX.Y.Z) are the single source of truth for versions.
+# (Radius.<Category>/vX.Y.Z and recipe-pack/<pack>/vX.Y.Z) are the single source
+# of truth for versions.
 
 BUMP ?= minor
 OUT_DIR ?= dist
@@ -31,19 +33,27 @@ test-release-automation: ## Run focused tests for namespace sync and release ver
 list-namespaces: ## List releasable namespaces (Radius.<Category>)
 	@./.github/scripts/release/list-namespaces.sh
 
+.PHONY: list-recipe-packs
+list-recipe-packs: ## List releasable recipe packs (recipepack/<pack>)
+	@./.github/scripts/release/list-recipe-packs.sh
+
 .PHONY: next-version
-next-version: ## Show current/next version for a namespace (requires NAMESPACE; optional BUMP=patch|minor|major, PRERELEASE_LABEL)
-ifndef NAMESPACE
-	$(error NAMESPACE parameter is required. Usage: make next-version NAMESPACE=Radius.Data BUMP=minor)
+next-version: ## Show current/next version for a namespace or recipe pack (requires NAMESPACE or RECIPE_PACK; optional BUMP=patch|minor|major, PRERELEASE_LABEL)
+ifeq ($(strip $(NAMESPACE))$(strip $(RECIPE_PACK)),)
+	$(error NAMESPACE or RECIPE_PACK parameter is required. Usage: make next-version NAMESPACE=Radius.Data BUMP=minor | make next-version RECIPE_PACK=kubernetes BUMP=minor)
 endif
-	@NAMESPACE="$(NAMESPACE)" BUMP="$(BUMP)" PRERELEASE_LABEL="$(PRERELEASE_LABEL)" ./.github/scripts/release/next-version.sh
+	@NAMESPACE="$(NAMESPACE)" RECIPE_PACK="$(RECIPE_PACK)" BUMP="$(BUMP)" PRERELEASE_LABEL="$(PRERELEASE_LABEL)" ./.github/scripts/release/next-version.sh
 
 .PHONY: release-bundle
-release-bundle: ## Build a namespace manifest bundle locally (requires NAMESPACE, VERSION; optional OUT_DIR)
-ifndef NAMESPACE
-	$(error NAMESPACE parameter is required. Usage: make release-bundle NAMESPACE=Radius.Data VERSION=0.1.0)
+release-bundle: ## Build a namespace manifest or recipe pack bundle locally (requires NAMESPACE or RECIPE_PACK, and VERSION; optional OUT_DIR)
+ifeq ($(strip $(NAMESPACE))$(strip $(RECIPE_PACK)),)
+	$(error NAMESPACE or RECIPE_PACK parameter is required. Usage: make release-bundle NAMESPACE=Radius.Data VERSION=0.1.0 | make release-bundle RECIPE_PACK=kubernetes VERSION=0.1.0)
 endif
 ifndef VERSION
 	$(error VERSION parameter is required. Usage: make release-bundle NAMESPACE=Radius.Data VERSION=0.1.0)
 endif
-	@NAMESPACE="$(NAMESPACE)" VERSION="$(VERSION)" OUT_DIR="$(OUT_DIR)" ./.github/scripts/release/build-namespace-bundle.sh
+	@if [ -n "$(RECIPE_PACK)" ]; then \
+		RECIPE_PACK="$(RECIPE_PACK)" VERSION="$(VERSION)" OUT_DIR="$(OUT_DIR)" ./.github/scripts/release/build-recipe-pack-bundle.sh; \
+	else \
+		NAMESPACE="$(NAMESPACE)" VERSION="$(VERSION)" OUT_DIR="$(OUT_DIR)" ./.github/scripts/release/build-namespace-bundle.sh; \
+	fi

--- a/.github/build/release.mk
+++ b/.github/build/release.mk
@@ -42,12 +42,18 @@ next-version: ## Show current/next version for a namespace or recipe pack (requi
 ifeq ($(strip $(NAMESPACE))$(strip $(RECIPE_PACK)),)
 	$(error NAMESPACE or RECIPE_PACK parameter is required. Usage: make next-version NAMESPACE=Radius.Data BUMP=minor | make next-version RECIPE_PACK=kubernetes BUMP=minor)
 endif
+ifneq ($(and $(strip $(NAMESPACE)),$(strip $(RECIPE_PACK))),)
+	$(error NAMESPACE and RECIPE_PACK are mutually exclusive. Set exactly one of them)
+endif
 	@NAMESPACE="$(NAMESPACE)" RECIPE_PACK="$(RECIPE_PACK)" BUMP="$(BUMP)" PRERELEASE_LABEL="$(PRERELEASE_LABEL)" ./.github/scripts/release/next-version.sh
 
 .PHONY: release-bundle
 release-bundle: ## Build a namespace manifest or recipe pack bundle locally (requires NAMESPACE or RECIPE_PACK, and VERSION; optional OUT_DIR)
 ifeq ($(strip $(NAMESPACE))$(strip $(RECIPE_PACK)),)
 	$(error NAMESPACE or RECIPE_PACK parameter is required. Usage: make release-bundle NAMESPACE=Radius.Data VERSION=0.1.0 | make release-bundle RECIPE_PACK=kubernetes VERSION=0.1.0)
+endif
+ifneq ($(and $(strip $(NAMESPACE)),$(strip $(RECIPE_PACK))),)
+	$(error NAMESPACE and RECIPE_PACK are mutually exclusive. Set exactly one of them)
 endif
 ifndef VERSION
 	$(error VERSION parameter is required. Usage: make release-bundle NAMESPACE=Radius.Data VERSION=0.1.0)

--- a/.github/build/release.mk
+++ b/.github/build/release.mk
@@ -34,7 +34,7 @@ list-namespaces: ## List releasable namespaces (Radius.<Category>)
 	@./.github/scripts/release/list-namespaces.sh
 
 .PHONY: list-recipe-packs
-list-recipe-packs: ## List releasable recipe packs (recipepack/<pack>)
+list-recipe-packs: ## List releasable recipe packs (recipe-packs/<pack>)
 	@./.github/scripts/release/list-recipe-packs.sh
 
 .PHONY: next-version

--- a/.github/scripts/compute-radius-sync-payload.sh
+++ b/.github/scripts/compute-radius-sync-payload.sh
@@ -161,8 +161,8 @@ case "$EVENT_NAME" in
             if rtc_is_category "$scope"; then
                 add_namespace "Radius.$scope"
             else
-                # A non-category scope (e.g. recipe-packs/...) is not a manifest
-                # namespace, so nothing is dispatched.
+                # A non-category scope (e.g. recipe-pack/kubernetes/v0.1.0) is
+                # not a manifest namespace, so nothing is dispatched.
                 REASON="non-namespace-scope"
             fi
         else

--- a/.github/scripts/release/build-namespace-bundle.sh
+++ b/.github/scripts/release/build-namespace-bundle.sh
@@ -68,69 +68,43 @@ if [[ ! -d "$FOLDER_ABS" ]]; then
     exit 1
 fi
 
-STAGING="$(mktemp -d)"
-cleanup() { rm -rf "$STAGING"; }
-trap cleanup EXIT
-
-count=0
-add_file() {
-    local src="$1" rel
-    rel="${src#"$RTC_REPO_ROOT"/}"
-    mkdir -p "$STAGING/$(dirname "$rel")"
-    cp "$src" "$STAGING/$rel"
-}
+STAGING_COUNT=0
+rtc_bundle_begin
 
 # Collect resource-type manifests (<category>/<type>/<file>.yaml) and each
 # type's adjacent README.md.
 while IFS= read -r manifest; do
     rtc_is_resource_type_yaml "$manifest" || continue
-    add_file "$manifest"
-    count=$((count + 1))
+    rtc_bundle_add_file "$manifest"
+    STAGING_COUNT=$((STAGING_COUNT + 1))
     type_dir="$(dirname "$manifest")"
     if [[ -f "$type_dir/README.md" ]]; then
-        add_file "$type_dir/README.md"
+        rtc_bundle_add_file "$type_dir/README.md"
     fi
 done < <(find "$FOLDER_ABS" -mindepth 2 -maxdepth 2 -type f \
     \( -name '*.yaml' -o -name '*.yml' \) | sort)
 
 # Include a namespace-level README.md when present.
 if [[ -f "$FOLDER_ABS/README.md" ]]; then
-    add_file "$FOLDER_ABS/README.md"
+    rtc_bundle_add_file "$FOLDER_ABS/README.md"
 fi
 
-if [[ "$count" -eq 0 ]]; then
+if [[ "$STAGING_COUNT" -eq 0 ]]; then
     echo "Error: no resource-type manifests found under '$FOLDER'" >&2
     exit 1
 fi
 
-mkdir -p "$OUT_DIR"
-OUT_DIR_ABS="$(cd "$OUT_DIR" && pwd)"
-ASSET_NAME="${NAMESPACE}-manifests-v${VERSION}.tar.gz"
-ASSET="$OUT_DIR_ABS/$ASSET_NAME"
+rtc_bundle_create "$OUT_DIR" "${NAMESPACE}-manifests-v${VERSION}.tar.gz"
 
-# Deterministic archive: fixed order/mtime/ownership so the checksum is stable.
-tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner \
-    -czf "$ASSET" -C "$STAGING" .
-
-CHECKSUMS="$OUT_DIR_ABS/checksums.txt"
-(cd "$OUT_DIR_ABS" && sha256sum "$ASSET_NAME" >"checksums.txt")
-
-emit() {
-    local key="$1" value="$2"
-    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-        printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
-    fi
-}
-
-emit "asset" "$ASSET"
-emit "checksums" "$CHECKSUMS"
-emit "count" "$count"
+rtc_emit "asset" "$RTC_BUNDLE_ASSET"
+rtc_emit "checksums" "$RTC_BUNDLE_CHECKSUMS"
+rtc_emit "count" "$STAGING_COUNT"
 
 {
     echo "Namespace:   $NAMESPACE"
     echo "Version:     $VERSION"
-    echo "Manifests:   $count"
-    echo "Asset:       $ASSET"
-    echo "Checksums:   $CHECKSUMS"
-    echo "SHA256:      $(cut -d' ' -f1 "$CHECKSUMS")"
+    echo "Manifests:   $STAGING_COUNT"
+    echo "Asset:       $RTC_BUNDLE_ASSET"
+    echo "Checksums:   $RTC_BUNDLE_CHECKSUMS"
+    echo "SHA256:      $(cut -d' ' -f1 "$RTC_BUNDLE_CHECKSUMS")"
 } >&2

--- a/.github/scripts/release/build-recipe-pack-bundle.sh
+++ b/.github/scripts/release/build-recipe-pack-bundle.sh
@@ -21,7 +21,7 @@
 # -----------------------------------------------------------------------------
 # Package a recipe pack into a release bundle plus a checksums file. The bundle
 # contains the pack's Bicep templates and its README.md, laid out under the
-# repo-relative path (e.g. `recipepack/kubernetes/default-recipepack.bicep`) so
+# repo-relative path (e.g. `recipe-packs/kubernetes/default-recipepack.bicep`) so
 # it extracts back into the same tree. This is the recipe pack counterpart of
 # build-namespace-bundle.sh and shares its bundling helpers.
 #
@@ -67,7 +67,7 @@ PACK_DIR_ABS="$RTC_REPO_ROOT/$PACK_DIR"
 STAGING_COUNT=0
 rtc_bundle_begin
 
-# Collect the pack's Bicep templates (recipepack/<pack>/<file>.bicep).
+# Collect the pack's Bicep templates (recipe-packs/<pack>/<file>.bicep).
 while IFS= read -r template; do
     rtc_bundle_add_file "$template"
     STAGING_COUNT=$((STAGING_COUNT + 1))

--- a/.github/scripts/release/build-recipe-pack-bundle.sh
+++ b/.github/scripts/release/build-recipe-pack-bundle.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# ------------------------------------------------------------
+# Copyright 2025 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# =============================================================================
+# build-recipe-pack-bundle.sh
+# -----------------------------------------------------------------------------
+# Package a recipe pack into a release bundle plus a checksums file. The bundle
+# contains the pack's Bicep templates and its README.md, laid out under the
+# repo-relative path (e.g. `recipepack/kubernetes/default-recipepack.bicep`) so
+# it extracts back into the same tree. This is the recipe pack counterpart of
+# build-namespace-bundle.sh and shares its bundling helpers.
+#
+# Inputs (environment variables):
+#   RECIPE_PACK   required, e.g. kubernetes
+#   VERSION       required, e.g. 0.2.0 (no leading `v`)
+#   OUT_DIR       output directory (default: dist)
+#   REPO_ROOT     repository root (default: git toplevel, else CWD)
+#   GITHUB_OUTPUT optional; when set, outputs are written there too
+#
+# Outputs (stdout summary + $GITHUB_OUTPUT):
+#   asset       path to the .tar.gz bundle
+#   checksums   path to the checksums.txt
+#   count       number of Bicep templates bundled
+#
+# Usage:
+#   RECIPE_PACK=kubernetes VERSION=0.1.0 ./.github/scripts/release/build-recipe-pack-bundle.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/release/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+RECIPE_PACK="${RECIPE_PACK:-}"
+VERSION="${VERSION:-}"
+OUT_DIR="${OUT_DIR:-dist}"
+
+if [[ -z "$RECIPE_PACK" || -z "$VERSION" ]]; then
+    echo "Error: RECIPE_PACK and VERSION are required" >&2
+    exit 1
+fi
+
+if ! rtc_is_recipe_pack "$RECIPE_PACK"; then
+    echo "Error: '$RECIPE_PACK' is not a releasable recipe pack" >&2
+    exit 1
+fi
+
+PACK_DIR="$(rtc_recipe_pack_dir "$RECIPE_PACK")"
+PACK_DIR_ABS="$RTC_REPO_ROOT/$PACK_DIR"
+
+STAGING_COUNT=0
+rtc_bundle_begin
+
+# Collect the pack's Bicep templates (recipepack/<pack>/<file>.bicep).
+while IFS= read -r template; do
+    rtc_bundle_add_file "$template"
+    STAGING_COUNT=$((STAGING_COUNT + 1))
+done < <(find "$PACK_DIR_ABS" -mindepth 1 -maxdepth 1 -type f -name '*.bicep' | sort)
+
+# Include the pack README.md when present.
+if [[ -f "$PACK_DIR_ABS/README.md" ]]; then
+    rtc_bundle_add_file "$PACK_DIR_ABS/README.md"
+fi
+
+if [[ "$STAGING_COUNT" -eq 0 ]]; then
+    echo "Error: no Bicep templates found under '$PACK_DIR'" >&2
+    exit 1
+fi
+
+rtc_bundle_create "$OUT_DIR" "${RTC_RECIPE_PACK_TAG_PREFIX}-${RECIPE_PACK}-v${VERSION}.tar.gz"
+
+rtc_emit "asset" "$RTC_BUNDLE_ASSET"
+rtc_emit "checksums" "$RTC_BUNDLE_CHECKSUMS"
+rtc_emit "count" "$STAGING_COUNT"
+
+{
+    echo "Recipe pack: $RECIPE_PACK"
+    echo "Version:     $VERSION"
+    echo "Templates:   $STAGING_COUNT"
+    echo "Asset:       $RTC_BUNDLE_ASSET"
+    echo "Checksums:   $RTC_BUNDLE_CHECKSUMS"
+    echo "SHA256:      $(cut -d' ' -f1 "$RTC_BUNDLE_CHECKSUMS")"
+} >&2

--- a/.github/scripts/release/lib.sh
+++ b/.github/scripts/release/lib.sh
@@ -19,17 +19,23 @@
 # =============================================================================
 # lib.sh
 # -----------------------------------------------------------------------------
-# Shared helpers for the per-namespace release tooling. Source this from the
-# other scripts in this directory:
+# Shared helpers for the release tooling. Source this from the other scripts in
+# this directory:
 #
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   source "$SCRIPT_DIR/lib.sh"
 #
-# A "namespace" is `Radius.<Category>` (e.g. Radius.Data) and maps 1:1 to a
-# top-level category directory (e.g. Data/). Each namespace is versioned and
-# tagged independently: tags are `Radius.<Category>/v<major>.<minor>.<patch>`
-# (optionally with a `-<prerelease>` suffix), and git tags are the single source
-# of truth for the current version -- there is no version file to keep in sync.
+# Two kinds of units are released independently, each on its own tag series:
+#
+#   * namespace    `Radius.<Category>` (e.g. Radius.Data), mapping 1:1 to a
+#                  top-level category directory (e.g. Data/).
+#                  tag: Radius.<Category>/v<major>.<minor>.<patch>[-<prerelease>]
+#   * recipe pack  a directory under recipepack/ (e.g. recipepack/kubernetes).
+#                  tag: recipe-pack/<pack>/v<major>.<minor>.<patch>[-<prerelease>]
+#
+# In both cases git tags are the single source of truth for the current version
+# -- there is no version file to keep in sync -- and a tag is always
+# `<prefix>/v<version>`, where the prefix identifies the released unit.
 # =============================================================================
 
 # Guard against double-sourcing.
@@ -44,13 +50,48 @@ RTC_RELEASE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/lib-namespaces.sh
 source "$RTC_RELEASE_LIB_DIR/../lib-namespaces.sh"
 
+# Recipe packs live one directory below this root. Their tags carry a
+# `recipe-pack/` prefix so they never collide with the namespace tag series and
+# so the Radius sync tooling can recognize them as a non-namespace scope.
+RTC_RECIPE_PACK_ROOT="${RTC_RECIPE_PACK_ROOT:-recipepack}"
+RTC_RECIPE_PACK_TAG_PREFIX="recipe-pack"
+
+# Print the releasable recipe packs (directory names under recipepack/), one per
+# line, sorted. A directory is only treated as a pack when it holds a Bicep
+# template, so unrelated folders are never mistaken for a pack.
+rtc_list_recipe_packs() {
+    local dir
+    [[ -d "$RTC_REPO_ROOT/$RTC_RECIPE_PACK_ROOT" ]] || return 0
+    while IFS= read -r dir; do
+        if compgen -G "$dir/*.bicep" >/dev/null; then
+            echo "${dir##*/}"
+        fi
+    done < <(find "$RTC_REPO_ROOT/$RTC_RECIPE_PACK_ROOT" -mindepth 1 -maxdepth 1 -type d | sort)
+}
+
+# True if the argument is a known recipe pack (e.g. "kubernetes").
+rtc_is_recipe_pack() {
+    local pack="$1" candidate
+    while IFS= read -r candidate; do
+        [[ "$candidate" == "$pack" ]] && return 0
+    done < <(rtc_list_recipe_packs)
+    return 1
+}
+
+# Map a recipe pack to its tag prefix and directory
+# (e.g. kubernetes -> recipe-pack/kubernetes, recipepack/kubernetes).
+rtc_recipe_pack_tag_prefix() { echo "${RTC_RECIPE_PACK_TAG_PREFIX}/$1"; }
+rtc_recipe_pack_dir() { echo "${RTC_RECIPE_PACK_ROOT}/$1"; }
+
 # Print the highest existing STABLE version (X.Y.Z, no prerelease suffix) for a
-# namespace, derived from git tags. Empty when the namespace has no release yet.
+# tag series, derived from git tags. `prefix` identifies the released unit (e.g.
+# `Radius.Data` or `recipe-pack/kubernetes`) and tags are `<prefix>/v<version>`.
+# Empty when the unit has no release yet.
 rtc_latest_version() {
-    local ns="$1" tag version
-    git -C "$RTC_REPO_ROOT" tag --list "${ns}/v*" 2>/dev/null |
+    local prefix="$1" tag version
+    git -C "$RTC_REPO_ROOT" tag --list "${prefix}/v*" 2>/dev/null |
         while IFS= read -r tag; do
-            version="${tag#"${ns}/v"}"
+            version="${tag#"${prefix}/v"}"
             if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                 echo "$version"
             fi
@@ -105,4 +146,58 @@ rtc_is_valid_prerelease() {
         fi
     done
     return 0
+}
+
+# Write a `key=value` step output when running under GitHub Actions; a no-op
+# locally so the same scripts work in both places.
+rtc_emit() {
+    local key="$1" value="$2"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Release bundles
+#
+# A bundle is a deterministic tarball of repository files laid out under their
+# repo-relative paths (so it extracts back into the same tree) plus a
+# checksums.txt. Shared by the namespace and recipe pack bundle builders:
+#
+#   rtc_bundle_begin
+#   rtc_bundle_add_file "<absolute path under the repo root>"
+#   rtc_bundle_create "$OUT_DIR" "<asset name>.tar.gz"
+#
+# rtc_bundle_create sets RTC_BUNDLE_ASSET and RTC_BUNDLE_CHECKSUMS.
+# -----------------------------------------------------------------------------
+RTC_BUNDLE_STAGING=""
+RTC_BUNDLE_ASSET=""
+RTC_BUNDLE_CHECKSUMS=""
+
+rtc_bundle_begin() {
+    RTC_BUNDLE_STAGING="$(mktemp -d)"
+    trap 'rm -rf "$RTC_BUNDLE_STAGING"' EXIT
+}
+
+rtc_bundle_add_file() {
+    local src="$1" rel
+    rel="${src#"$RTC_REPO_ROOT"/}"
+    mkdir -p "$RTC_BUNDLE_STAGING/$(dirname "$rel")"
+    cp "$src" "$RTC_BUNDLE_STAGING/$rel"
+}
+
+rtc_bundle_create() {
+    local out_dir="$1" asset_name="$2" out_dir_abs
+    mkdir -p "$out_dir"
+    out_dir_abs="$(cd "$out_dir" && pwd)"
+    RTC_BUNDLE_ASSET="$out_dir_abs/$asset_name"
+
+    # Deterministic archive: fixed order/mtime/ownership so the checksum is
+    # stable across rebuilds of the same content.
+    tar --sort=name --mtime='@0' --owner=0 --group=0 --numeric-owner \
+        -czf "$RTC_BUNDLE_ASSET" -C "$RTC_BUNDLE_STAGING" .
+
+    # shellcheck disable=SC2034 # read by the sourcing bundle script
+    RTC_BUNDLE_CHECKSUMS="$out_dir_abs/checksums.txt"
+    (cd "$out_dir_abs" && sha256sum "$asset_name" >"checksums.txt")
 }

--- a/.github/scripts/release/lib.sh
+++ b/.github/scripts/release/lib.sh
@@ -30,7 +30,7 @@
 #   * namespace    `Radius.<Category>` (e.g. Radius.Data), mapping 1:1 to a
 #                  top-level category directory (e.g. Data/).
 #                  tag: Radius.<Category>/v<major>.<minor>.<patch>[-<prerelease>]
-#   * recipe pack  a directory under recipepack/ (e.g. recipepack/kubernetes).
+#   * recipe pack  a directory under recipe-packs/ (e.g. recipe-packs/kubernetes).
 #                  tag: recipe-pack/<pack>/v<major>.<minor>.<patch>[-<prerelease>]
 #
 # In both cases git tags are the single source of truth for the current version
@@ -56,7 +56,7 @@ source "$RTC_RELEASE_LIB_DIR/../lib-namespaces.sh"
 RTC_RECIPE_PACK_ROOT="${RTC_RECIPE_PACK_ROOT:-recipepack}"
 RTC_RECIPE_PACK_TAG_PREFIX="recipe-pack"
 
-# Print the releasable recipe packs (directory names under recipepack/), one per
+# Print the releasable recipe packs (directory names under recipe-packs/), one per
 # line, sorted. A directory is only treated as a pack when it holds a Bicep
 # template, so unrelated folders are never mistaken for a pack.
 rtc_list_recipe_packs() {
@@ -79,7 +79,7 @@ rtc_is_recipe_pack() {
 }
 
 # Map a recipe pack to its tag prefix and directory
-# (e.g. kubernetes -> recipe-pack/kubernetes, recipepack/kubernetes).
+# (e.g. kubernetes -> recipe-pack/kubernetes, recipe-packs/kubernetes).
 rtc_recipe_pack_tag_prefix() { echo "${RTC_RECIPE_PACK_TAG_PREFIX}/$1"; }
 rtc_recipe_pack_dir() { echo "${RTC_RECIPE_PACK_ROOT}/$1"; }
 

--- a/.github/scripts/release/lib.sh
+++ b/.github/scripts/release/lib.sh
@@ -169,12 +169,18 @@ rtc_emit() {
 #   rtc_bundle_create "$OUT_DIR" "<asset name>.tar.gz"
 #
 # rtc_bundle_create sets RTC_BUNDLE_ASSET and RTC_BUNDLE_CHECKSUMS.
+# rtc_bundle_begin fixes the umask for the rest of the run so staged file modes
+# -- and therefore the checksum -- do not depend on the caller's environment.
 # -----------------------------------------------------------------------------
 RTC_BUNDLE_STAGING=""
 RTC_BUNDLE_ASSET=""
 RTC_BUNDLE_CHECKSUMS=""
 
 rtc_bundle_begin() {
+    # `mkdir` and `cp` mask the mode they create files with, so an unusual
+    # caller umask (e.g. 077) would otherwise change the modes recorded in the
+    # archive and produce a different checksum for identical content.
+    umask 022
     RTC_BUNDLE_STAGING="$(mktemp -d)"
     trap 'rm -rf "$RTC_BUNDLE_STAGING"' EXIT
 }

--- a/.github/scripts/release/lib.sh
+++ b/.github/scripts/release/lib.sh
@@ -53,7 +53,7 @@ source "$RTC_RELEASE_LIB_DIR/../lib-namespaces.sh"
 # Recipe packs live one directory below this root. Their tags carry a
 # `recipe-pack/` prefix so they never collide with the namespace tag series and
 # so the Radius sync tooling can recognize them as a non-namespace scope.
-RTC_RECIPE_PACK_ROOT="${RTC_RECIPE_PACK_ROOT:-recipepack}"
+RTC_RECIPE_PACK_ROOT="${RTC_RECIPE_PACK_ROOT:-recipe-packs}"
 RTC_RECIPE_PACK_TAG_PREFIX="recipe-pack"
 
 # Print the releasable recipe packs (directory names under recipe-packs/), one per

--- a/.github/scripts/release/list-recipe-packs.sh
+++ b/.github/scripts/release/list-recipe-packs.sh
@@ -19,7 +19,7 @@
 # =============================================================================
 # list-recipe-packs.sh
 # -----------------------------------------------------------------------------
-# Print the releasable recipe packs (directory names under recipepack/), one per
+# Print the releasable recipe packs (directory names under recipe-packs/), one per
 # line. Each is versioned and released independently by
 # release-recipe-pack.yaml under the `recipe-pack/<pack>/vX.Y.Z` tag series.
 #

--- a/.github/scripts/release/list-recipe-packs.sh
+++ b/.github/scripts/release/list-recipe-packs.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# ------------------------------------------------------------
+# Copyright 2025 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# =============================================================================
+# list-recipe-packs.sh
+# -----------------------------------------------------------------------------
+# Print the releasable recipe packs (directory names under recipepack/), one per
+# line. Each is versioned and released independently by
+# release-recipe-pack.yaml under the `recipe-pack/<pack>/vX.Y.Z` tag series.
+#
+# Usage:
+#   ./.github/scripts/release/list-recipe-packs.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/release/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+rtc_list_recipe_packs

--- a/.github/scripts/release/next-version.sh
+++ b/.github/scripts/release/next-version.sh
@@ -19,12 +19,14 @@
 # =============================================================================
 # next-version.sh
 # -----------------------------------------------------------------------------
-# Resolve the current and next version for a namespace from git tags, and print
-# the tag to create. Git tags are the single source of truth; there is no
-# version file to maintain.
+# Resolve the current and next version for a namespace or a recipe pack from git
+# tags, and print the tag to create. Git tags are the single source of truth;
+# there is no version file to maintain.
 #
 # Inputs (environment variables):
-#   NAMESPACE         required, e.g. Radius.Data
+#   NAMESPACE         a namespace to release, e.g. Radius.Data
+#   RECIPE_PACK       a recipe pack to release, e.g. kubernetes
+#                     (exactly one of NAMESPACE or RECIPE_PACK is required)
 #   BUMP              patch|minor|major (default: minor)
 #   PRERELEASE_LABEL  optional, e.g. rc.1 or beta.1; when set, appended as
 #                     `-<label>` and the release is treated as a prerelease
@@ -34,11 +36,13 @@
 # Outputs (stdout summary + $GITHUB_OUTPUT):
 #   current           highest existing stable version (or "none")
 #   next              resolved next version (e.g. 0.2.0 or 0.2.0-rc.1)
-#   tag               full tag to create (e.g. Radius.Data/v0.2.0)
+#   tag               full tag to create (e.g. Radius.Data/v0.2.0 or
+#                     recipe-pack/kubernetes/v0.2.0)
 #   is_prerelease     "true" | "false"
 #
 # Usage:
 #   NAMESPACE=Radius.Data BUMP=minor ./.github/scripts/release/next-version.sh
+#   RECIPE_PACK=kubernetes BUMP=minor ./.github/scripts/release/next-version.sh
 # =============================================================================
 
 set -euo pipefail
@@ -48,21 +52,40 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib.sh"
 
 NAMESPACE="${NAMESPACE:-}"
+RECIPE_PACK="${RECIPE_PACK:-}"
 BUMP="${BUMP:-minor}"
 PRERELEASE_LABEL="${PRERELEASE_LABEL:-}"
 
-if [[ -z "$NAMESPACE" ]]; then
-    echo "Error: NAMESPACE is required (e.g. NAMESPACE=Radius.Data)" >&2
+if [[ -n "$NAMESPACE" && -n "$RECIPE_PACK" ]]; then
+    echo "Error: set either NAMESPACE or RECIPE_PACK, not both" >&2
     exit 1
 fi
 
-if ! rtc_is_namespace "$NAMESPACE"; then
-    echo "Error: '$NAMESPACE' is not a releasable namespace. Known namespaces:" >&2
-    rtc_list_namespaces | sed 's/^/  - /' >&2
+# Resolve the released unit into its tag prefix; tags are `<prefix>/v<version>`.
+if [[ -n "$RECIPE_PACK" ]]; then
+    if ! rtc_is_recipe_pack "$RECIPE_PACK"; then
+        echo "Error: '$RECIPE_PACK' is not a releasable recipe pack. Known recipe packs:" >&2
+        rtc_list_recipe_packs | sed 's/^/  - /' >&2
+        exit 1
+    fi
+    UNIT_LABEL="Recipe pack:"
+    UNIT="$RECIPE_PACK"
+    PREFIX="$(rtc_recipe_pack_tag_prefix "$RECIPE_PACK")"
+elif [[ -n "$NAMESPACE" ]]; then
+    if ! rtc_is_namespace "$NAMESPACE"; then
+        echo "Error: '$NAMESPACE' is not a releasable namespace. Known namespaces:" >&2
+        rtc_list_namespaces | sed 's/^/  - /' >&2
+        exit 1
+    fi
+    UNIT_LABEL="Namespace:"
+    UNIT="$NAMESPACE"
+    PREFIX="$NAMESPACE"
+else
+    echo "Error: NAMESPACE or RECIPE_PACK is required (e.g. NAMESPACE=Radius.Data or RECIPE_PACK=kubernetes)" >&2
     exit 1
 fi
 
-CURRENT="$(rtc_latest_version "$NAMESPACE")"
+CURRENT="$(rtc_latest_version "$PREFIX")"
 BASE="${CURRENT:-0.0.0}"
 NEXT="$(rtc_semver_bump "$BASE" "$BUMP")"
 
@@ -78,30 +101,23 @@ if [[ -n "$PRERELEASE_LABEL" ]]; then
     IS_PRERELEASE="true"
 fi
 
-TAG="${NAMESPACE}/v${NEXT}"
+TAG="${PREFIX}/v${NEXT}"
 
 if git -C "$RTC_REPO_ROOT" rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
     echo "Error: tag '${TAG}' already exists" >&2
     exit 1
 fi
 
-emit() {
-    local key="$1" value="$2"
-    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-        printf '%s=%s\n' "$key" "$value" >>"$GITHUB_OUTPUT"
-    fi
-}
-
-emit "current" "${CURRENT:-none}"
-emit "next" "$NEXT"
-emit "tag" "$TAG"
-emit "is_prerelease" "$IS_PRERELEASE"
+rtc_emit "current" "${CURRENT:-none}"
+rtc_emit "next" "$NEXT"
+rtc_emit "tag" "$TAG"
+rtc_emit "is_prerelease" "$IS_PRERELEASE"
 
 {
-    echo "Namespace:     $NAMESPACE"
-    echo "Current:       ${CURRENT:-none}"
-    echo "Bump:          $BUMP"
-    echo "Next:          $NEXT"
-    echo "Tag:           $TAG"
-    echo "Prerelease:    $IS_PRERELEASE"
+    printf '%-14s %s\n' "$UNIT_LABEL" "$UNIT"
+    printf '%-14s %s\n' "Current:" "${CURRENT:-none}"
+    printf '%-14s %s\n' "Bump:" "$BUMP"
+    printf '%-14s %s\n' "Next:" "$NEXT"
+    printf '%-14s %s\n' "Tag:" "$TAG"
+    printf '%-14s %s\n' "Prerelease:" "$IS_PRERELEASE"
 } >&2

--- a/.github/scripts/tests/test-release-automation.sh
+++ b/.github/scripts/tests/test-release-automation.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SYNC_SCRIPT="${REPO_ROOT}/.github/scripts/compute-radius-sync-payload.sh"
 VERSION_SCRIPT="${REPO_ROOT}/.github/scripts/release/next-version.sh"
+BUNDLE_SCRIPT="${REPO_ROOT}/.github/scripts/release/build-recipe-pack-bundle.sh"
 TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rtc-release-tests-XXXXXX")"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
@@ -55,6 +56,20 @@ types:
 EOF
     git -C "$repo" add .
     git -C "$repo" commit -q -m "add ${category} manifest"
+}
+
+create_recipe_pack_repo() {
+    local repo="$1" pack="$2"
+    git init -q "$repo"
+    git -C "$repo" config user.name "Release Test"
+    git -C "$repo" config user.email "release-test@example.com"
+    mkdir -p "$repo/recipepack/$pack"
+    cat >"$repo/recipepack/$pack/default-recipepack.bicep" <<'EOF'
+extension radius
+EOF
+    echo "# ${pack} recipe pack" >"$repo/recipepack/$pack/README.md"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "add ${pack} recipe pack"
 }
 
 test_deleted_namespace() {
@@ -102,8 +117,67 @@ test_prerelease_labels() {
     done
 }
 
+test_recipe_pack_versioning() {
+    local repo="$TEST_ROOT/recipe-pack" output="$TEST_ROOT/recipe-pack.out"
+    create_recipe_pack_repo "$repo" "kubernetes"
+
+    REPO_ROOT="$repo" RECIPE_PACK=kubernetes BUMP=minor GITHUB_OUTPUT="$output" \
+        bash "$VERSION_SCRIPT" >/dev/null 2>&1 || fail "initial recipe pack version was rejected"
+    assert_eq "none" "$(output_value "$output" current)" "initial recipe pack current version"
+    assert_eq "recipe-pack/kubernetes/v0.1.0" "$(output_value "$output" tag)" "initial recipe pack tag"
+
+    git -C "$repo" tag "recipe-pack/kubernetes/v0.1.0"
+    : >"$output"
+    REPO_ROOT="$repo" RECIPE_PACK=kubernetes BUMP=patch PRERELEASE_LABEL=rc.1 \
+        GITHUB_OUTPUT="$output" bash "$VERSION_SCRIPT" >/dev/null 2>&1 ||
+        fail "recipe pack patch bump was rejected"
+    assert_eq "0.1.0" "$(output_value "$output" current)" "recipe pack current version"
+    assert_eq "recipe-pack/kubernetes/v0.1.1-rc.1" "$(output_value "$output" tag)" "recipe pack prerelease tag"
+    assert_eq "true" "$(output_value "$output" is_prerelease)" "recipe pack prerelease flag"
+
+    if REPO_ROOT="$repo" RECIPE_PACK=does-not-exist bash "$VERSION_SCRIPT" >/dev/null 2>&1; then
+        fail "unknown recipe pack was accepted"
+    fi
+
+    if REPO_ROOT="$repo" NAMESPACE=Radius.Data RECIPE_PACK=kubernetes \
+        bash "$VERSION_SCRIPT" >/dev/null 2>&1; then
+        fail "NAMESPACE and RECIPE_PACK together were accepted"
+    fi
+}
+
+test_recipe_pack_bundle() {
+    local repo="$TEST_ROOT/recipe-pack-bundle" output="$TEST_ROOT/recipe-pack-bundle.out" asset
+    create_recipe_pack_repo "$repo" "kubernetes"
+
+    (cd "$repo" && REPO_ROOT="$repo" RECIPE_PACK=kubernetes VERSION=0.1.0 \
+        GITHUB_OUTPUT="$output" bash "$BUNDLE_SCRIPT" >/dev/null 2>&1) ||
+        fail "recipe pack bundle build failed"
+
+    asset="$(output_value "$output" asset)"
+    assert_eq "recipe-pack-kubernetes-v0.1.0.tar.gz" "$(basename "$asset")" "recipe pack asset name"
+    assert_eq "1" "$(output_value "$output" count)" "recipe pack template count"
+    [[ -f "$asset" ]] || fail "recipe pack asset was not created"
+    tar -tzf "$asset" | grep -q 'recipepack/kubernetes/default-recipepack.bicep' ||
+        fail "recipe pack bundle is missing the pack template"
+    tar -tzf "$asset" | grep -q 'recipepack/kubernetes/README.md' ||
+        fail "recipe pack bundle is missing the pack README"
+}
+
+test_recipe_pack_release_is_not_synced() {
+    local repo="$TEST_ROOT/recipe-pack-sync" output="$TEST_ROOT/recipe-pack-sync.out"
+    create_repo "$repo" "Data"
+
+    REPO_ROOT="$repo" EVENT_NAME=release RELEASE_TAG="recipe-pack/kubernetes/v0.1.0" \
+        GITHUB_OUTPUT="$output" bash "$SYNC_SCRIPT" >/dev/null 2>&1
+    assert_eq "0" "$(output_value "$output" namespace_count)" "recipe pack release namespace count"
+    assert_eq "non-namespace-scope" "$(output_value "$output" reason)" "recipe pack release skip reason"
+}
+
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 test_deleted_namespace
 test_renamed_namespace
 test_prerelease_labels
+test_recipe_pack_versioning
+test_recipe_pack_bundle
+test_recipe_pack_release_is_not_synced
 echo "Release automation tests passed"

--- a/.github/scripts/tests/test-release-automation.sh
+++ b/.github/scripts/tests/test-release-automation.sh
@@ -63,11 +63,11 @@ create_recipe_pack_repo() {
     git init -q "$repo"
     git -C "$repo" config user.name "Release Test"
     git -C "$repo" config user.email "release-test@example.com"
-    mkdir -p "$repo/recipepack/$pack"
-    cat >"$repo/recipepack/$pack/default-recipepack.bicep" <<'EOF'
+    mkdir -p "$repo/recipe-packs/$pack"
+    cat >"$repo/recipe-packs/$pack/default-recipepack.bicep" <<'EOF'
 extension radius
 EOF
-    echo "# ${pack} recipe pack" >"$repo/recipepack/$pack/README.md"
+    echo "# ${pack} recipe pack" >"$repo/recipe-packs/$pack/README.md"
     git -C "$repo" add .
     git -C "$repo" commit -q -m "add ${pack} recipe pack"
 }
@@ -157,9 +157,9 @@ test_recipe_pack_bundle() {
     assert_eq "recipe-pack-kubernetes-v0.1.0.tar.gz" "$(basename "$asset")" "recipe pack asset name"
     assert_eq "1" "$(output_value "$output" count)" "recipe pack template count"
     [[ -f "$asset" ]] || fail "recipe pack asset was not created"
-    tar -tzf "$asset" | grep -q 'recipepack/kubernetes/default-recipepack.bicep' ||
+    tar -tzf "$asset" | grep -q 'recipe-packs/kubernetes/default-recipepack.bicep' ||
         fail "recipe pack bundle is missing the pack template"
-    tar -tzf "$asset" | grep -q 'recipepack/kubernetes/README.md' ||
+    tar -tzf "$asset" | grep -q 'recipe-packs/kubernetes/README.md' ||
         fail "recipe pack bundle is missing the pack README"
 }
 

--- a/.github/workflows/release-recipe-pack.yaml
+++ b/.github/workflows/release-recipe-pack.yaml
@@ -1,0 +1,209 @@
+# yaml-language-server: $schema=https://www.schemastore.org/github-workflow.json
+---
+name: Release Recipe Pack
+
+# Cuts an independent, per-recipe-pack release of the Recipe Packs.
+#
+# Each pack (a directory under `recipepack/`) is versioned and tagged on its own
+# series, prefixed so it never collides with the namespace tag series:
+#   tag:     recipe-pack/<pack>/v<major>.<minor>.<patch>[-<prerelease>]
+#   asset:   recipe-pack-<pack>-v<version>.tar.gz  (+ checksums.txt)
+#
+# Every published release artifact gets a signed SLSA build provenance
+# attestation (actions/attest-build-provenance), verifiable with
+#   gh attestation verify <asset> --repo radius-project/resource-types-contrib
+#
+# Git tags are the single source of truth for the current version -- there is no
+# version file to maintain. A maintainer triggers this workflow, picks the pack
+# and a bump type, and the workflow computes the next version, builds the pack
+# bundle, and publishes a GitHub Release. This mirrors release-namespace.yaml and
+# shares its release scripts.
+#
+# Downstream: publishing the release fires `notify-radius.yaml` on
+# `release: published`, which recognizes the `recipe-pack/` scope as a
+# non-namespace scope and sends no sync dispatch to radius-project/radius --
+# Recipe Packs are not part of the default resource-type manifests. The release
+# is still created with the RESOURCE_TYPES_BOT GitHub App token (not
+# GITHUB_TOKEN) so release events behave consistently across both workflows.
+#
+# Prerequisite (one-time, admin): the RESOURCE_TYPES_BOT GitHub App must be
+# installed on this repository with `contents: write` so it can create the tag
+# and release. `dry_run` needs no token and is safe to run anytime.
+#
+# To release a new recipe pack folder, add it to the `recipe_pack` choice list
+# below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      recipe_pack:
+        description: Recipe pack to release
+        type: choice
+        required: true
+        options:
+          - azure
+          - kubernetes
+      bump:
+        description: Semantic version bump
+        type: choice
+        required: true
+        default: minor
+        options:
+          - patch
+          - minor
+          - major
+      prerelease_label:
+        description: "Optional prerelease label (e.g. rc.1, beta.1); marks the release as a prerelease"
+        type: string
+        required: false
+        default: ""
+      dry_run:
+        description: Compute the version and build the bundle without tagging or publishing
+        type: boolean
+        required: false
+        default: false
+
+permissions: {}
+
+concurrency:
+  # One release at a time per recipe pack; never cancel an in-flight release.
+  group: release-recipe-pack-${{ inputs.recipe_pack }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release recipe pack ${{ inputs.recipe_pack }}
+    if: >-
+      github.repository == 'radius-project/resource-types-contrib' &&
+      (inputs.dry_run || github.ref == 'refs/heads/main')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      # Read is enough for checkout; the tag/release is created with the App
+      # token so release events behave the same as for namespace releases.
+      contents: read
+      # Sign and record a build provenance attestation for the release artifact.
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags so version resolution and release notes work.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Resolve version
+        id: ver
+        env:
+          RECIPE_PACK: ${{ inputs.recipe_pack }}
+          BUMP: ${{ inputs.bump }}
+          PRERELEASE_LABEL: ${{ inputs.prerelease_label }}
+        run: ./.github/scripts/release/next-version.sh
+
+      - name: Build recipe pack bundle
+        id: bundle
+        env:
+          RECIPE_PACK: ${{ inputs.recipe_pack }}
+          VERSION: ${{ steps.ver.outputs.next }}
+          OUT_DIR: dist
+        run: ./.github/scripts/release/build-recipe-pack-bundle.sh
+
+      - name: Generate release notes
+        id: notes
+        env:
+          RECIPE_PACK: ${{ inputs.recipe_pack }}
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          folder="recipepack/${RECIPE_PACK}"
+          prev="$(git tag --list "recipe-pack/${RECIPE_PACK}/v*" --sort=-v:refname | head -n1 || true)"
+          if [ -n "$prev" ]; then
+            range="${prev}..HEAD"
+          else
+            range="HEAD"
+          fi
+          {
+            echo "## ${TAG}"
+            echo ""
+            if [ -n "$prev" ]; then
+              echo "Changes in \`${folder}/\` since \`${prev}\`:"
+            else
+              echo "Initial release of the \`${RECIPE_PACK}\` recipe pack."
+            fi
+            echo ""
+            changes="$(git log --no-merges --pretty='- %s (%h)' "$range" -- "${folder}/" || true)"
+            if [ -n "$changes" ]; then
+              echo "$changes"
+            else
+              echo "- No recipe pack changes since the previous release."
+            fi
+          } > dist/notes.md
+          {
+            echo "prev=${prev:-none}"
+          } >> "$GITHUB_OUTPUT"
+          echo "--- release notes ---"
+          cat dist/notes.md
+
+      - name: Attest build provenance
+        # Generate a signed SLSA build provenance attestation for the release
+        # bundle so consumers can cryptographically verify it was built by this
+        # workflow and has not been tampered with. Runs before publishing so a
+        # released artifact is always attested (fail-closed). Verify with:
+        #   gh attestation verify <asset> --repo radius-project/resource-types-contrib
+        if: ${{ !inputs.dry_run }}
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: ${{ steps.bundle.outputs.asset }}
+
+      - name: Generate App Token
+        # Create the release as the RESOURCE_TYPES_BOT App (not GITHUB_TOKEN) so
+        # release events are allowed to trigger downstream workflows. Requires
+        # the App installed on this repo with contents:write.
+        if: ${{ !inputs.dry_run }}
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.RESOURCE_TYPES_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.RESOURCE_TYPES_BOT_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Create tag and GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          IS_PRERELEASE: ${{ steps.ver.outputs.is_prerelease }}
+          ASSET: ${{ steps.bundle.outputs.asset }}
+          CHECKSUMS: ${{ steps.bundle.outputs.checksums }}
+        run: |
+          set -euo pipefail
+          args=(--target "$GITHUB_SHA" --title "$TAG" --notes-file dist/notes.md --latest=false)
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "$TAG" "${args[@]}" "$ASSET" "$CHECKSUMS"
+
+      - name: Summarize
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          {
+            echo "## Release ${{ steps.ver.outputs.tag }}"
+            echo ""
+            echo "* Recipe pack: \`${{ inputs.recipe_pack }}\`"
+            echo "* Current -> next: \`${{ steps.ver.outputs.current }}\` -> \`${{ steps.ver.outputs.next }}\`"
+            echo "* Since previous tag: \`${{ steps.notes.outputs.prev }}\`"
+            echo "* Prerelease: \`${{ steps.ver.outputs.is_prerelease }}\`"
+            echo "* Templates bundled: \`${{ steps.bundle.outputs.count }}\`"
+            echo "* Asset: \`$(basename "${{ steps.bundle.outputs.asset }}")\`"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo ""
+              echo "_Dry run: no tag, release, or attestation was created._"
+            else
+              echo "* Provenance: attested (verify with \`gh attestation verify <asset> --repo ${{ github.repository }}\`)"
+              echo ""
+              echo "Published as \`${{ steps.ver.outputs.tag }}\`; no radius sync dispatch is sent for recipe pack releases."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-recipe-pack.yaml
+++ b/.github/workflows/release-recipe-pack.yaml
@@ -4,7 +4,7 @@ name: Release Recipe Pack
 
 # Cuts an independent, per-recipe-pack release of the Recipe Packs.
 #
-# Each pack (a directory under `recipepack/`) is versioned and tagged on its own
+# Each pack (a directory under `recipe-packs/`) is versioned and tagged on its own
 # series, prefixed so it never collides with the namespace tag series:
 #   tag:     recipe-pack/<pack>/v<major>.<minor>.<patch>[-<prerelease>]
 #   asset:   recipe-pack-<pack>-v<version>.tar.gz  (+ checksums.txt)
@@ -117,7 +117,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p dist
-          folder="recipepack/${RECIPE_PACK}"
+          folder="recipe-packs/${RECIPE_PACK}"
           prev="$(git tag --list "recipe-pack/${RECIPE_PACK}/v*" --sort=-v:refname | head -n1 || true)"
           if [ -n "$prev" ]; then
             range="${prev}..HEAD"


### PR DESCRIPTION
<!--
Thank you for contributing to Radius! Please fill out each section below so
reviewers have the context they need. Sections marked optional can be removed
if they do not apply.
-->

## Summary

Add functionality to support the release of recipe packs, including scripts for listing and building recipe pack bundles.

## Reason for change

This change introduces the ability to manage recipe packs similarly to namespaces, allowing for independent versioning and releases.

## How to test

1. Use the `list-recipe-packs` command to verify that it lists available recipe packs.
2. Test the `release-bundle` command with both namespaces and recipe packs to ensure proper functionality.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| .github/scripts/release/list-recipe-packs.sh | New script to list releasable recipe packs. |
| .github/scripts/release/build-recipe-pack-bundle.sh | New script to package a recipe pack into a release bundle. |
| Makefile | Updated to include targets for recipe packs. |
| Other files | Adjusted logic to accommodate recipe pack handling. |

