### PR TITLE
feat: enhance sync payload to support recipe packs and update related workflows

### DIFF
--- a/.github/scripts/compute-radius-sync-payload.sh
+++ b/.github/scripts/compute-radius-sync-payload.sh
@@ -20,8 +20,8 @@
 # compute-radius-sync-payload.sh
 # -----------------------------------------------------------------------------
 # Build the `repository_dispatch` client-payload that notify-radius.yaml sends
-# to radius-project/radius so it can re-sync its default resource-type
-# manifests.
+# to radius-project/radius so it can re-sync what it consumes from this
+# repository.
 #
 # This implements the resource-types-contrib side of the "sync default resource
 # types without a fake Go module" design (radius PR #12236), Phase A:
@@ -29,18 +29,31 @@
 #   * Option 3 (pinned git-ref) + Option 6 (automated PR sync), together the
 #     "hybrid": the payload carries an immutable pin (a commit SHA on the moving
 #     channel, or a release tag on the release channel) that the Radius bot
-#     records as `source.ref` / `sources[].ref` and re-syncs via a reviewable PR.
-#   * Per-namespace variant: instead of one repository-wide pin, the payload
-#     lists exactly the `Radius.<Category>` namespaces affected by this event,
-#     each with its ref, so Radius can advance only the namespaces that changed.
+#     records in `deploy/manifest/defaults.yaml` and re-syncs via a reviewable
+#     PR.
+#   * Per-unit variant: instead of one repository-wide pin, the payload lists
+#     exactly the units affected by this event, so Radius advances only what
+#     changed. Two kinds of units are dispatched, matching the two pin sections
+#     Radius keeps in defaults.yaml (radius PR #12567):
+#       - namespaces    `Radius.<Category>` manifest namespaces -> resourceTypes[]
+#       - recipe packs  directories under recipe-packs/         -> recipePacks[]
 #
 # Channels:
 #   * edge    -> push to `main`. Ref is the pushed commit SHA (immutable, even
-#                though it is repository-wide in Phase A). Affected namespaces
-#                are derived from the manifest YAML files changed in the push.
+#                though it is repository-wide in Phase A). Affected units are
+#                derived from the files changed in the push.
 #   * release -> a published release. Ref is the release tag. A scope-prefixed
-#                tag (e.g. `Compute/containers/v0.1.0` or `Radius.Data/v0.2.0`)
-#                affects just that namespace; a plain `vX.Y.Z` tag affects all.
+#                tag affects just that unit -- `Radius.Data/v0.2.0` a namespace,
+#                `recipe-pack/azure/v0.2.0` a recipe pack -- while a plain
+#                `vX.Y.Z` tag affects every unit.
+#
+# Payload shape (consumed by the Radius contrib-update-resource-types.yaml
+# workflow, which accepts `namespace` as a legacy alias for `name`):
+#   {
+#     channel, contrib_repo, contrib_ref, actor,
+#     namespaces:   [ {name, namespace, ref}, ... ],
+#     recipe_packs: [ {name, ref}, ... ]
+#   }
 #
 # Inputs (environment variables, normally supplied by the workflow):
 #   EVENT_NAME    github.event_name           ("push" | "release")
@@ -54,15 +67,20 @@
 #                                              to stderr only)
 #
 # Outputs (written to $GITHUB_OUTPUT when set):
-#   channel          the resolved channel ("edge" | "release")
-#   ref              the immutable pin (commit SHA or release tag)
-#   namespace_count  number of affected namespaces (0 => nothing to dispatch)
-#   affected         comma-separated affected namespaces
-#   payload          compact JSON client-payload (only when namespace_count > 0)
+#   channel                the resolved channel ("edge" | "release")
+#   ref                    the immutable pin (commit SHA or release tag)
+#   namespace_count        number of affected namespaces
+#   affected               comma-separated affected namespaces
+#   recipe_pack_count      number of affected recipe packs
+#   affected_recipe_packs  comma-separated affected recipe packs
+#   unit_count             total affected units (0 => nothing to dispatch)
+#   reason                 why nothing was dispatched (only when unit_count is 0)
+#   payload                compact JSON client-payload (only when unit_count > 0)
 #
 # Usage:
 #   EVENT_NAME=push BEFORE_SHA=<sha> AFTER_SHA=<sha> ./compute-radius-sync-payload.sh
-#   EVENT_NAME=release RELEASE_TAG=Compute/containers/v0.1.0 ./compute-radius-sync-payload.sh
+#   EVENT_NAME=release RELEASE_TAG=Radius.Compute/v0.1.0 ./compute-radius-sync-payload.sh
+#   EVENT_NAME=release RELEASE_TAG=recipe-pack/azure/v0.1.0 ./compute-radius-sync-payload.sh
 # =============================================================================
 
 set -euo pipefail
@@ -92,8 +110,10 @@ source "$SCRIPT_DIR/lib-namespaces.sh"
 # Reason recorded when nothing is dispatched (surfaced in the workflow summary).
 REASON=""
 
-# Accumulator for affected namespaces (deduplicated, insertion order preserved).
+# Accumulators for affected units (deduplicated, insertion order preserved).
 declare -a AFFECTED_NS=()
+declare -a AFFECTED_PACKS=()
+
 add_namespace() {
     local ns="$1" existing
     for existing in "${AFFECTED_NS[@]:-}"; do
@@ -102,12 +122,28 @@ add_namespace() {
     AFFECTED_NS+=("$ns")
 }
 
+add_recipe_pack() {
+    local pack="$1" existing
+    for existing in "${AFFECTED_PACKS[@]:-}"; do
+        [[ "$existing" == "$pack" ]] && return 0
+    done
+    AFFECTED_PACKS+=("$pack")
+}
+
 add_all_namespaces() {
     local cat
     while IFS= read -r cat; do
         [[ -z "$cat" ]] && continue
         add_namespace "Radius.$cat"
     done < <(rtc_list_folders)
+}
+
+add_all_recipe_packs() {
+    local pack
+    while IFS= read -r pack; do
+        [[ -z "$pack" ]] && continue
+        add_recipe_pack "$pack"
+    done < <(rtc_list_recipe_packs)
 }
 
 # True when path is a resource-type manifest at ref. Reading from the commit,
@@ -137,6 +173,22 @@ add_namespace_for_path_at_ref() {
     fi
 }
 
+# Recipe pack membership is decided by path alone (recipe-packs/<pack>/...), so
+# a pack whose files were deleted or renamed by the push is still dispatched --
+# Radius skips any name it does not pin.
+add_recipe_pack_for_path() {
+    local path="$1" rest pack
+    [[ "$path" == "$RTC_RECIPE_PACK_ROOT"/* ]] || return 0
+    rest="${path#"$RTC_RECIPE_PACK_ROOT"/}"
+    # Files directly under recipe-packs/ (e.g. a shared README) belong to no pack.
+    [[ "$rest" == */* ]] || return 0
+    pack="${rest%%/*}"
+    case "$pack" in
+        "" | *[!A-Za-z0-9._-]*) return 0 ;;
+    esac
+    add_recipe_pack "$pack"
+}
+
 CHANNEL=""
 REF=""
 
@@ -153,6 +205,15 @@ case "$EVENT_NAME" in
             # tracks the same commits on main, and the release channel pins
             # stable tags only.
             REASON="prerelease"
+        elif [[ "$REF" == "$RTC_RECIPE_PACK_TAG_PREFIX"/*/* ]]; then
+            # Recipe pack tag: recipe-pack/<pack>/vX.Y.Z.
+            pack="${REF#"$RTC_RECIPE_PACK_TAG_PREFIX"/}"
+            pack="${pack%%/*}"
+            if rtc_is_recipe_pack "$pack"; then
+                add_recipe_pack "$pack"
+            else
+                REASON="unknown-recipe-pack"
+            fi
         elif [[ "$REF" == */* ]]; then
             # Scope-prefixed tag: the first path segment names the scope.
             # Tolerate both "Compute/..." and "Radius.Compute/..." forms.
@@ -161,13 +222,14 @@ case "$EVENT_NAME" in
             if rtc_is_category "$scope"; then
                 add_namespace "Radius.$scope"
             else
-                # A non-category scope (e.g. recipe-pack/kubernetes/v0.1.0) is
-                # not a manifest namespace, so nothing is dispatched.
-                REASON="non-namespace-scope"
+                # A scope that is neither a namespace nor a recipe pack names
+                # nothing Radius consumes, so nothing is dispatched.
+                REASON="unknown-scope"
             fi
         else
-            # Plain repository-wide tag (vX.Y.Z): every namespace advances.
+            # Plain repository-wide tag (vX.Y.Z): every unit advances.
             add_all_namespaces
+            add_all_recipe_packs
         fi
         ;;
     push | "")
@@ -191,17 +253,21 @@ case "$EVENT_NAME" in
                         IFS= read -r -d '' new_path
                         add_namespace_for_path_at_ref "$old_path" "$BEFORE_SHA"
                         add_namespace_for_path_at_ref "$new_path" "$AFTER_SHA"
+                        add_recipe_pack_for_path "$old_path"
+                        add_recipe_pack_for_path "$new_path"
                         ;;
                     *)
                         add_namespace_for_path_at_ref "$old_path" "$BEFORE_SHA"
                         add_namespace_for_path_at_ref "$old_path" "$AFTER_SHA"
+                        add_recipe_pack_for_path "$old_path"
                         ;;
                 esac
             done < <(git -C "$REPO_ROOT" diff --name-status --find-renames -z "$BEFORE_SHA" "$AFTER_SHA")
         else
             # No usable diff (new branch, shallow clone, or unrelated
-            # force-push): fall back to the safe superset of all namespaces.
+            # force-push): fall back to the safe superset of every unit.
             add_all_namespaces
+            add_all_recipe_packs
         fi
         ;;
     *)
@@ -210,27 +276,43 @@ case "$EVENT_NAME" in
         ;;
 esac
 
-COUNT="${#AFFECTED_NS[@]}"
-AFFECTED_CSV="$(
+NS_COUNT="${#AFFECTED_NS[@]}"
+PACK_COUNT="${#AFFECTED_PACKS[@]}"
+UNIT_COUNT=$((NS_COUNT + PACK_COUNT))
+AFFECTED_NS_CSV="$(
     IFS=,
     echo "${AFFECTED_NS[*]:-}"
 )"
+AFFECTED_PACKS_CSV="$(
+    IFS=,
+    echo "${AFFECTED_PACKS[*]:-}"
+)"
+
+# Render unit names as a compact JSON array of pin objects. Namespace entries
+# repeat the name under `namespace` as well: Radius reads `name` and keeps
+# `namespace` as a legacy alias, so one payload satisfies both.
+pins_json() {
+    local with_alias="$1"
+    shift
+    printf '%s\n' "$@" |
+        jq -R -c --arg ref "$REF" --argjson alias "$with_alias" \
+            'select(length > 0) |
+             if $alias then {name: ., namespace: ., ref: $ref} else {name: ., ref: $ref} end' |
+        jq -s -c '.'
+}
 
 PAYLOAD=""
-if [[ "$COUNT" -gt 0 ]]; then
-    namespaces_json="$(
-        printf '%s\n' "${AFFECTED_NS[@]}" |
-            jq -R -c --arg ref "$REF" 'select(length > 0) | {namespace: ., ref: $ref}' |
-            jq -s -c '.'
-    )"
+if [[ "$UNIT_COUNT" -gt 0 ]]; then
     PAYLOAD="$(
         jq -c -n \
             --arg channel "$CHANNEL" \
             --arg repo "$CONTRIB_REPO" \
             --arg ref "$REF" \
             --arg actor "$ACTOR" \
-            --argjson namespaces "$namespaces_json" \
-            '{channel: $channel, contrib_repo: $repo, contrib_ref: $ref, namespaces: $namespaces, actor: $actor}'
+            --argjson namespaces "$(pins_json true "${AFFECTED_NS[@]:-}")" \
+            --argjson recipe_packs "$(pins_json false "${AFFECTED_PACKS[@]:-}")" \
+            '{channel: $channel, contrib_repo: $repo, contrib_ref: $ref,
+              namespaces: $namespaces, recipe_packs: $recipe_packs, actor: $actor}'
     )"
 fi
 
@@ -241,27 +323,31 @@ emit() {
     fi
 }
 
-if [[ "$COUNT" -eq 0 && -z "$REASON" ]]; then
-    REASON="no-namespace-changes"
+if [[ "$UNIT_COUNT" -eq 0 && -z "$REASON" ]]; then
+    REASON="no-relevant-changes"
 fi
 
 emit "channel" "$CHANNEL"
 emit "ref" "$REF"
-emit "namespace_count" "$COUNT"
-emit "affected" "$AFFECTED_CSV"
+emit "namespace_count" "$NS_COUNT"
+emit "affected" "$AFFECTED_NS_CSV"
+emit "recipe_pack_count" "$PACK_COUNT"
+emit "affected_recipe_packs" "$AFFECTED_PACKS_CSV"
+emit "unit_count" "$UNIT_COUNT"
 emit "reason" "$REASON"
-if [[ "$COUNT" -gt 0 ]]; then
+if [[ "$UNIT_COUNT" -gt 0 ]]; then
     emit "payload" "$PAYLOAD"
 fi
 
 {
-    echo "Event:      $EVENT_NAME"
-    echo "Channel:    $CHANNEL"
-    echo "Ref:        $REF"
-    echo "Namespaces: ${AFFECTED_CSV:-<none>} ($COUNT)"
-    if [[ "$COUNT" -gt 0 ]]; then
-        echo "Payload:    $PAYLOAD"
+    echo "Event:        $EVENT_NAME"
+    echo "Channel:      $CHANNEL"
+    echo "Ref:          $REF"
+    echo "Namespaces:   ${AFFECTED_NS_CSV:-<none>} ($NS_COUNT)"
+    echo "Recipe packs: ${AFFECTED_PACKS_CSV:-<none>} ($PACK_COUNT)"
+    if [[ "$UNIT_COUNT" -gt 0 ]]; then
+        echo "Payload:      $PAYLOAD"
     else
-        echo "Payload:    <none - skipped: ${REASON:-none}>"
+        echo "Payload:      <none - skipped: ${REASON:-none}>"
     fi
 } >&2

--- a/.github/scripts/lib-namespaces.sh
+++ b/.github/scripts/lib-namespaces.sh
@@ -19,16 +19,20 @@
 # =============================================================================
 # lib-namespaces.sh
 # -----------------------------------------------------------------------------
-# Shared helpers for enumerating resource-type namespaces and mapping them to
-# their category directories. Sourced by both the Radius sync payload script
-# (compute-radius-sync-payload.sh) and the per-namespace release tooling
-# (release/lib.sh) so there is ONE definition of what a namespace is.
+# Shared helpers for enumerating the two kinds of units this repository
+# publishes -- resource-type namespaces and recipe packs -- and mapping them to
+# their directories. Sourced by both the Radius sync payload script
+# (compute-radius-sync-payload.sh) and the release tooling (release/lib.sh) so
+# there is ONE definition of each unit.
 #
 # A namespace is `Radius.<Category>` and maps 1:1 to a top-level category
 # directory (e.g. Radius.Data <-> Data/). A directory is only treated as a
 # category when it actually contains a resource-type manifest -- a YAML file
 # with a top-level `namespace: Radius.*` and a `types:` block -- so unrelated
 # top-level folders are never mistaken for namespaces.
+#
+# A recipe pack is a directory under recipe-packs/ (e.g. recipe-packs/azure)
+# that holds at least one Bicep template.
 #
 # Usage:
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -124,3 +128,36 @@ rtc_is_namespace() {
     done < <(rtc_list_namespaces)
     return 1
 }
+
+# Recipe packs live one directory below this root. Their tags carry a
+# `recipe-pack/` prefix so they never collide with the namespace tag series and
+# so the Radius sync tooling can recognize the scope.
+RTC_RECIPE_PACK_ROOT="${RTC_RECIPE_PACK_ROOT:-recipe-packs}"
+RTC_RECIPE_PACK_TAG_PREFIX="recipe-pack"
+
+# Print the releasable recipe packs (directory names under recipe-packs/), one
+# per line, sorted. A directory is only treated as a pack when it holds a Bicep
+# template, so unrelated folders are never mistaken for a pack.
+rtc_list_recipe_packs() {
+    local dir
+    [[ -d "$RTC_REPO_ROOT/$RTC_RECIPE_PACK_ROOT" ]] || return 0
+    while IFS= read -r dir; do
+        if compgen -G "$dir/*.bicep" >/dev/null; then
+            echo "${dir##*/}"
+        fi
+    done < <(find "$RTC_REPO_ROOT/$RTC_RECIPE_PACK_ROOT" -mindepth 1 -maxdepth 1 -type d | sort)
+}
+
+# True if the argument is a known recipe pack (e.g. "kubernetes").
+rtc_is_recipe_pack() {
+    local pack="$1" candidate
+    while IFS= read -r candidate; do
+        [[ "$candidate" == "$pack" ]] && return 0
+    done < <(rtc_list_recipe_packs)
+    return 1
+}
+
+# Map a recipe pack to its tag prefix and directory
+# (e.g. kubernetes -> recipe-pack/kubernetes, recipe-packs/kubernetes).
+rtc_recipe_pack_tag_prefix() { echo "${RTC_RECIPE_PACK_TAG_PREFIX}/$1"; }
+rtc_recipe_pack_dir() { echo "${RTC_RECIPE_PACK_ROOT}/$1"; }

--- a/.github/scripts/publish-bicep-recipe.sh
+++ b/.github/scripts/publish-bicep-recipe.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# ------------------------------------------------------------
+# Copyright 2025 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# =============================================================================
+# Publish one Kubernetes Bicep recipe to a container registry under every tag in
+# $TAGS. Called once per recipe by the publish-bicep-recipes workflow, which
+# runs the invocations as parallel steps in a single job.
+#
+# Arguments:
+#   $1  recipe name, used as the registry repository (e.g. containers)
+#   $2  path to the Bicep recipe, relative to the repository root
+#
+# Inputs (environment variables):
+#   REGISTRY  required, e.g. ghcr.io/radius-project/kube-recipes
+#   TAGS      required, space-separated tags, e.g. "0.51.0 latest"
+#
+# Usage:
+#   ./publish-bicep-recipe.sh containers Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+# =============================================================================
+
+set -euo pipefail
+
+NAME="${1:?recipe name is required}"
+RECIPE_PATH="${2:?recipe path is required}"
+: "${REGISTRY:?REGISTRY is required}"
+: "${TAGS:?TAGS is required}"
+
+read -ra tags <<<"$TAGS"
+
+for tag in "${tags[@]}"; do
+    target="br:${REGISTRY}/${NAME}:${tag}"
+    echo "Publishing ${RECIPE_PATH} to ${target}"
+    rad bicep publish --file "$RECIPE_PATH" --target "$target"
+done

--- a/.github/scripts/release/lib.sh
+++ b/.github/scripts/release/lib.sh
@@ -44,44 +44,11 @@ if [[ -n "${RTC_RELEASE_LIB_SOURCED:-}" ]]; then
 fi
 RTC_RELEASE_LIB_SOURCED=1
 
-# Namespace enumeration and folder<->namespace mapping are shared with the
-# Radius sync tooling so there is a single source of truth.
+# Namespace and recipe pack enumeration, plus the folder<->unit mapping, are
+# shared with the Radius sync tooling so there is a single source of truth.
 RTC_RELEASE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/lib-namespaces.sh
 source "$RTC_RELEASE_LIB_DIR/../lib-namespaces.sh"
-
-# Recipe packs live one directory below this root. Their tags carry a
-# `recipe-pack/` prefix so they never collide with the namespace tag series and
-# so the Radius sync tooling can recognize them as a non-namespace scope.
-RTC_RECIPE_PACK_ROOT="${RTC_RECIPE_PACK_ROOT:-recipe-packs}"
-RTC_RECIPE_PACK_TAG_PREFIX="recipe-pack"
-
-# Print the releasable recipe packs (directory names under recipe-packs/), one per
-# line, sorted. A directory is only treated as a pack when it holds a Bicep
-# template, so unrelated folders are never mistaken for a pack.
-rtc_list_recipe_packs() {
-    local dir
-    [[ -d "$RTC_REPO_ROOT/$RTC_RECIPE_PACK_ROOT" ]] || return 0
-    while IFS= read -r dir; do
-        if compgen -G "$dir/*.bicep" >/dev/null; then
-            echo "${dir##*/}"
-        fi
-    done < <(find "$RTC_REPO_ROOT/$RTC_RECIPE_PACK_ROOT" -mindepth 1 -maxdepth 1 -type d | sort)
-}
-
-# True if the argument is a known recipe pack (e.g. "kubernetes").
-rtc_is_recipe_pack() {
-    local pack="$1" candidate
-    while IFS= read -r candidate; do
-        [[ "$candidate" == "$pack" ]] && return 0
-    done < <(rtc_list_recipe_packs)
-    return 1
-}
-
-# Map a recipe pack to its tag prefix and directory
-# (e.g. kubernetes -> recipe-pack/kubernetes, recipe-packs/kubernetes).
-rtc_recipe_pack_tag_prefix() { echo "${RTC_RECIPE_PACK_TAG_PREFIX}/$1"; }
-rtc_recipe_pack_dir() { echo "${RTC_RECIPE_PACK_ROOT}/$1"; }
 
 # Print the highest existing STABLE version (X.Y.Z, no prerelease suffix) for a
 # tag series, derived from git tags. `prefix` identifies the released unit (e.g.

--- a/.github/scripts/tests/test-release-automation.sh
+++ b/.github/scripts/tests/test-release-automation.sh
@@ -163,14 +163,64 @@ test_recipe_pack_bundle() {
         fail "recipe pack bundle is missing the pack README"
 }
 
-test_recipe_pack_release_is_not_synced() {
-    local repo="$TEST_ROOT/recipe-pack-sync" output="$TEST_ROOT/recipe-pack-sync.out"
-    create_repo "$repo" "Data"
+test_recipe_pack_release_is_synced() {
+    local repo="$TEST_ROOT/recipe-pack-sync" output="$TEST_ROOT/recipe-pack-sync.out" payload
+    create_recipe_pack_repo "$repo" "kubernetes"
 
     REPO_ROOT="$repo" EVENT_NAME=release RELEASE_TAG="recipe-pack/kubernetes/v0.1.0" \
         GITHUB_OUTPUT="$output" bash "$SYNC_SCRIPT" >/dev/null 2>&1
     assert_eq "0" "$(output_value "$output" namespace_count)" "recipe pack release namespace count"
-    assert_eq "non-namespace-scope" "$(output_value "$output" reason)" "recipe pack release skip reason"
+    assert_eq "1" "$(output_value "$output" recipe_pack_count)" "recipe pack release pack count"
+    assert_eq "kubernetes" "$(output_value "$output" affected_recipe_packs)" "recipe pack release affected pack"
+
+    payload="$(output_value "$output" payload)"
+    assert_eq '[{"name":"kubernetes","ref":"recipe-pack/kubernetes/v0.1.0"}]' \
+        "$(jq -c '.recipe_packs' <<<"$payload")" "recipe pack release payload pins"
+    assert_eq "[]" "$(jq -c '.namespaces' <<<"$payload")" "recipe pack release payload namespaces"
+
+    : >"$output"
+    REPO_ROOT="$repo" EVENT_NAME=release RELEASE_TAG="recipe-pack/does-not-exist/v0.1.0" \
+        GITHUB_OUTPUT="$output" bash "$SYNC_SCRIPT" >/dev/null 2>&1
+    assert_eq "0" "$(output_value "$output" unit_count)" "unknown recipe pack unit count"
+    assert_eq "unknown-recipe-pack" "$(output_value "$output" reason)" "unknown recipe pack skip reason"
+}
+
+test_recipe_pack_push_is_synced() {
+    local repo="$TEST_ROOT/recipe-pack-push" output="$TEST_ROOT/recipe-pack-push.out" before after payload
+    create_recipe_pack_repo "$repo" "azure"
+    before="$(git -C "$repo" rev-parse HEAD)"
+    echo "// updated" >>"$repo/recipe-packs/azure/default-recipepack.bicep"
+    git -C "$repo" commit -q -am "update azure recipe pack"
+    after="$(git -C "$repo" rev-parse HEAD)"
+
+    REPO_ROOT="$repo" EVENT_NAME=push BEFORE_SHA="$before" AFTER_SHA="$after" \
+        GITHUB_OUTPUT="$output" bash "$SYNC_SCRIPT" >/dev/null 2>&1
+    assert_eq "0" "$(output_value "$output" namespace_count)" "recipe pack push namespace count"
+    assert_eq "azure" "$(output_value "$output" affected_recipe_packs)" "recipe pack push affected pack"
+
+    payload="$(output_value "$output" payload)"
+    assert_eq "$after" "$(jq -r '.recipe_packs[0].ref' <<<"$payload")" "recipe pack push pin ref"
+}
+
+test_repo_wide_release_covers_all_units() {
+    local repo="$TEST_ROOT/repo-wide" output="$TEST_ROOT/repo-wide.out" payload
+    create_repo "$repo" "Data"
+    mkdir -p "$repo/recipe-packs/kubernetes"
+    echo "extension radius" >"$repo/recipe-packs/kubernetes/default-recipepack.bicep"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "add kubernetes recipe pack"
+
+    REPO_ROOT="$repo" EVENT_NAME=release RELEASE_TAG="v0.1.0" \
+        GITHUB_OUTPUT="$output" bash "$SYNC_SCRIPT" >/dev/null 2>&1
+    assert_eq "2" "$(output_value "$output" unit_count)" "repo-wide release unit count"
+    assert_eq "Radius.Data" "$(output_value "$output" affected)" "repo-wide release namespaces"
+    assert_eq "kubernetes" "$(output_value "$output" affected_recipe_packs)" "repo-wide release recipe packs"
+
+    # Radius reads `name` and accepts `namespace` as a legacy alias; both must
+    # be present so one payload works with either consumer version.
+    payload="$(output_value "$output" payload)"
+    assert_eq "Radius.Data" "$(jq -r '.namespaces[0].name' <<<"$payload")" "repo-wide namespace name"
+    assert_eq "Radius.Data" "$(jq -r '.namespaces[0].namespace' <<<"$payload")" "repo-wide namespace alias"
 }
 
 command -v jq >/dev/null 2>&1 || fail "jq is required"
@@ -179,5 +229,7 @@ test_renamed_namespace
 test_prerelease_labels
 test_recipe_pack_versioning
 test_recipe_pack_bundle
-test_recipe_pack_release_is_not_synced
+test_recipe_pack_release_is_synced
+test_recipe_pack_push_is_synced
+test_repo_wide_release_covers_all_units
 echo "Release automation tests passed"

--- a/.github/workflows/notify-radius.yaml
+++ b/.github/workflows/notify-radius.yaml
@@ -3,45 +3,54 @@
 name: Notify Radius
 
 # Fires a `repository_dispatch` event to radius-project/radius so it can re-sync
-# its default resource-type manifests from this repository.
+# what it consumes from this repository.
 #
 # This is the resource-types-contrib side of the "sync default resource types
 # without a fake Go module" design (radius PR #12236), Phase A. It adopts the
 # hybrid of Option 3 (pinned git-ref) and Option 6 (automated, Dependabot-like
-# PR sync), with the per-namespace variant:
+# PR sync), with the per-unit variant:
 #
 #   * Option 3 (pinned git-ref): the dispatch carries an immutable pin -- the
 #     pushed commit SHA on the moving channel, or the release tag on the release
-#     channel -- that Radius records as `source.ref` / `sources[].ref`. The pin
+#     channel -- that Radius records in `deploy/manifest/defaults.yaml`. The pin
 #     is no longer "informational only" (the old fake-module model fetched via
 #     `go get ...@latest`); it is the exact revision Radius vendors.
 #   * Option 6 (automated PR sync): Radius's contrib-update-resource-types.yaml
 #     turns the dispatch into a reviewable `bot/update-resource-types` PR that
-#     runs `make update-resource-types`, surfacing the full YAML diff and the
-#     drift check + CI on every bump.
-#   * Per-namespace variant: the payload lists exactly the affected
-#     `Radius.<Category>` namespaces (each with its ref), so Radius advances only
-#     the namespaces this event actually changed instead of re-vendoring all of
-#     them.
+#     runs `make update-resource-types` / `make update-recipe-packs`, surfacing
+#     the full YAML diff and the drift check + CI on every bump.
+#   * Per-unit variant: the payload lists exactly the units this event affected,
+#     so Radius advances only those instead of re-vendoring everything. The two
+#     unit kinds match the two pin sections Radius keeps in defaults.yaml
+#     (radius PR #12567):
+#       - `namespaces`   -> `resourceTypes[]`, the `Radius.<Category>` manifests
+#                           that are copied into the Radius repo.
+#       - `recipe_packs` -> `recipePacks[]`, the packs under `recipe-packs/`.
+#                           Radius pins these but never vendors them; its deploy
+#                           workflows fetch the pack Bicep from here at deploy
+#                           time, so the pin records which revision they target.
 #
 # Channels (both delivered as a reviewable PR, nothing fetched at build/runtime):
 #   * edge    -> push to `main`. Keeps Radius `latest`/`edge` current with this
-#                repo's `main`; affected namespaces come from the changed
-#                manifest YAML files, pinned to the pushed commit SHA.
+#                repo's `main`; affected units come from the changed manifest
+#                YAML files and `recipe-packs/` files, pinned to the pushed
+#                commit SHA.
 #   * release -> a published release. Pins a stable upstream tag at Radius
-#                release time; a scope-prefixed tag affects a single namespace,
-#                a plain `vX.Y.Z` tag affects all.
+#                release time; a scope-prefixed tag affects a single namespace
+#                (`Radius.Data/vX.Y.Z`) or a single recipe pack
+#                (`recipe-pack/azure/vX.Y.Z`), a plain `vX.Y.Z` tag affects all.
 #
 # End-to-end flow:
-#   1. This workflow computes the per-namespace payload and fires
+#   1. This workflow computes the per-unit payload and fires
 #      repository_dispatch (event-type `resource-types-contrib-updated`).
 #   2. Radius's contrib-update-resource-types.yaml receives it and opens/refreshes
-#      a PR that re-runs the manifest copy for the pinned ref.
+#      a PR that re-runs the manifest copy and the pin rewrite for the pinned ref.
 #   3. A maintainer reviews the YAML diff and merges the PR.
 #
-# Note: only resource types listed in the Radius repo's
-# deploy/manifest/defaults.yaml ship as defaults. A namespace added here but not
-# registered there produces a dispatch with no effective changes and no PR.
+# Note: Radius only advances entries it already registers -- resource types
+# listed in its deploy/manifest/defaults.yaml `defaultRegistration`, and packs
+# listed under `recipePacks`. A namespace or pack added here but not registered
+# there produces a dispatch with no effective changes and no PR.
 #
 # See the design note in the radius repo:
 #   eng/design-notes/extensibility/2026-06-resource-types-sync-without-fake-go-module.md
@@ -59,6 +68,8 @@ on:
       - "**/*.yml"
       - "!.github/**"
       - "!docs/**"
+      # Recipe packs are Bicep, not YAML, and Radius pins them separately.
+      - recipe-packs/**
   release:
     # Release channel: pin a stable upstream tag at Radius release time.
     types:
@@ -90,11 +101,12 @@ jobs:
           # Full history so the per-namespace diff can resolve `event.before`.
           fetch-depth: 0
 
-      - name: Compute per-namespace sync payload
+      - name: Compute sync payload
         # Resolves the channel, the immutable pin (SHA or tag), and the set of
-        # affected `Radius.<Category>` namespaces, then emits the compact JSON
-        # client-payload. Emits namespace_count=0 when nothing relevant changed
-        # (e.g. a recipe-pack-only release), which short-circuits the dispatch.
+        # affected units -- `Radius.<Category>` namespaces and `recipe-packs/`
+        # packs -- then emits the compact JSON client-payload. Emits
+        # unit_count=0 when nothing relevant changed (e.g. a prerelease), which
+        # short-circuits the dispatch.
         id: payload
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -111,7 +123,7 @@ jobs:
         # is sent with scoped, auditable credentials. The app must be installed
         # on the target repo (radius-project/radius) with contents:write to
         # trigger repository_dispatch.
-        if: steps.payload.outputs.namespace_count != '0'
+        if: steps.payload.outputs.unit_count != '0'
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
@@ -125,10 +137,10 @@ jobs:
 
       - name: Send repository_dispatch to radius-project/radius
         # Fires the repository_dispatch event that Radius's
-        # contrib-update-resource-types.yaml workflow listens for. The
-        # per-namespace client-payload (channel, immutable ref, and the affected
-        # namespaces) is computed by the previous step.
-        if: steps.payload.outputs.namespace_count != '0'
+        # contrib-update-resource-types.yaml workflow listens for. The per-unit
+        # client-payload (channel, immutable ref, and the affected namespaces
+        # and recipe packs) is computed by the previous step.
+        if: steps.payload.outputs.unit_count != '0'
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -146,7 +158,8 @@ jobs:
             echo "* Channel: \`${{ steps.payload.outputs.channel }}\`"
             echo "* Ref: \`${{ steps.payload.outputs.ref }}\`"
             echo "* Affected namespaces (${{ steps.payload.outputs.namespace_count }}): \`${{ steps.payload.outputs.affected }}\`"
-            if [ "${{ steps.payload.outputs.namespace_count }}" = "0" ]; then
+            echo "* Affected recipe packs (${{ steps.payload.outputs.recipe_pack_count }}): \`${{ steps.payload.outputs.affected_recipe_packs }}\`"
+            if [ "${{ steps.payload.outputs.unit_count }}" = "0" ]; then
               echo ""
               echo "_No dispatch sent (reason: \`${{ steps.payload.outputs.reason }}\`)._"
             else

--- a/.github/workflows/publish-bicep-recipes.yaml
+++ b/.github/workflows/publish-bicep-recipes.yaml
@@ -2,11 +2,33 @@
 ---
 name: Publish Bicep Recipes
 
+# Publishes the Kubernetes Bicep recipes to GHCR as OCI artifacts.
+#
+# The tag channels mirror the release lifecycle implemented by
+# notify-radius.yaml, so a recipe image tag means the same thing as a sync pin:
+#   * edge      -> every push to `main` that touches a Bicep recipe, and manual
+#                  runs with no version. Floating tag; `edge` always resolves to
+#                  the newest recipes on `main`.
+#   * <version> -> manual dispatch with `release_version`, run alongside a
+#                  Radius release. Immutable; never republished.
+#   * latest    -> moves only with a stable `release_version`, so `latest`
+#                  always resolves to the newest stable release.
+
 on:
+  push:
+    branches:
+      - main
+    paths:
+      # Any Bicep recipe, so a new recipe folder is covered without editing
+      # this list; the publish steps below decide what actually gets published.
+      - "**/recipes/kubernetes/bicep/**"
+      # Republish when the recipe list or the publish script changes.
+      - .github/workflows/publish-bicep-recipes.yaml
+      - .github/scripts/publish-bicep-recipe.sh
   workflow_dispatch:
     inputs:
       release_version:
-        description: "Release version to use as the image tag (e.g. 0.51.0). Defaults to 'latest' if not specified."
+        description: Release version to use as the image tag (e.g. 0.51.0). Leave empty to refresh the floating edge tag.
         required: false
         default: ""
         type: string
@@ -15,36 +37,29 @@ permissions: {}
 
 env:
   REGISTRY: ghcr.io/radius-project/kube-recipes
-  TAG: ${{ inputs.release_version || 'latest' }}
+  # `latest` is only ever moved by a stable release version -- semver marks a
+  # prerelease with a `-` -- so it never resolves to an unreleased build.
+  TAGS: >-
+    ${{ github.event_name == 'push' && 'edge'
+        || inputs.release_version == '' && 'edge'
+        || contains(inputs.release_version, '-') && inputs.release_version
+        || format('{0} latest', inputs.release_version) }}
+
+concurrency:
+  # `edge` must end up at the newest commit on `main`, so let a newer push
+  # supersede an in-flight publish. Versioned publishes are never cancelled.
+  group: publish-bicep-recipes-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
   publish-bicep-recipes:
     name: Publish Bicep Recipes to GHCR
+    if: github.repository == 'radius-project/resource-types-contrib'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
       packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: containers
-            path: Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
-          - name: containerimages
-            path: Compute/containerImages/recipes/kubernetes/bicep/kubernetes-containerimages.bicep
-          - name: persistentvolumes
-            path: Compute/persistentVolumes/recipes/kubernetes/bicep/kubernetes-volumes.bicep
-          - name: routes
-            path: Compute/routes/recipes/kubernetes/bicep/kubernetes-routes.bicep
-          - name: secrets
-            path: Security/secrets/recipes/kubernetes/bicep/kubernetes-secrets.bicep
-          - name: mysqldatabases
-            path: Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
-          - name: postgresqldatabases
-            path: Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
-          - name: rediscaches
-            path: Data/redisCaches/recipes/kubernetes/bicep/kubernetes-redis.bicep
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -62,9 +77,27 @@ jobs:
         run: |
           wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | /bin/bash
 
-      - name: Publish ${{ matrix.name }} recipe
+      # Publishing every recipe from one job means checkout, login and the CLI
+      # install happen once instead of once per recipe. At most 10 of these run
+      # concurrently; the rest queue.
+      - parallel:
+          - name: Publish containers
+            run: ./.github/scripts/publish-bicep-recipe.sh containers Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+          - name: Publish containerimages
+            run: ./.github/scripts/publish-bicep-recipe.sh containerimages Compute/containerImages/recipes/kubernetes/bicep/kubernetes-containerimages.bicep
+          - name: Publish persistentvolumes
+            run: ./.github/scripts/publish-bicep-recipe.sh persistentvolumes Compute/persistentVolumes/recipes/kubernetes/bicep/kubernetes-volumes.bicep
+          - name: Publish routes
+            run: ./.github/scripts/publish-bicep-recipe.sh routes Compute/routes/recipes/kubernetes/bicep/kubernetes-routes.bicep
+          - name: Publish secrets
+            run: ./.github/scripts/publish-bicep-recipe.sh secrets Security/secrets/recipes/kubernetes/bicep/kubernetes-secrets.bicep
+          - name: Publish mysqldatabases
+            run: ./.github/scripts/publish-bicep-recipe.sh mysqldatabases Data/mySqlDatabases/recipes/kubernetes/bicep/kubernetes-mysql.bicep
+          - name: Publish postgresqldatabases
+            run: ./.github/scripts/publish-bicep-recipe.sh postgresqldatabases Data/postgreSqlDatabases/recipes/kubernetes/bicep/kubernetes-postgresql.bicep
+          - name: Publish rediscaches
+            run: ./.github/scripts/publish-bicep-recipe.sh rediscaches Data/redisCaches/recipes/kubernetes/bicep/kubernetes-redis.bicep
+
+      - name: Summarize
         run: |
-          echo "Publishing ${{ matrix.name }} recipe to ${{ env.REGISTRY }}/${{ matrix.name }}:${{ env.TAG }}"
-          rad bicep publish \
-            --file ${{ matrix.path }} \
-            --target "br:${{ env.REGISTRY }}/${{ matrix.name }}:${{ env.TAG }}"
+          echo "Published the Kubernetes Bicep recipes to \`$REGISTRY\` with tags \`$TAGS\`." >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-namespace.yaml
+++ b/.github/workflows/release-namespace.yaml
@@ -17,8 +17,8 @@ name: Release Namespace
 # namespace and a bump type, and the workflow computes the next version, builds
 # the manifest bundle, and publishes a GitHub Release. This is the release side
 # of the per-namespace sync design (radius PR #12236): publishing per-namespace
-# versioned artifacts is what makes Radius's per-namespace `sources[].ref` pins
-# meaningful.
+# versioned artifacts is what makes Radius's per-namespace `resourceTypes[].ref`
+# pins meaningful.
 #
 # Downstream: publishing the release fires `notify-radius.yaml` on
 # `release: published`, which dispatches the per-namespace pin (this tag) to

--- a/.github/workflows/release-recipe-pack.yaml
+++ b/.github/workflows/release-recipe-pack.yaml
@@ -20,11 +20,13 @@ name: Release Recipe Pack
 # shares its release scripts.
 #
 # Downstream: publishing the release fires `notify-radius.yaml` on
-# `release: published`, which recognizes the `recipe-pack/` scope as a
-# non-namespace scope and sends no sync dispatch to radius-project/radius --
-# Recipe Packs are not part of the default resource-type manifests. The release
-# is still created with the RESOURCE_TYPES_BOT GitHub App token (not
-# GITHUB_TOKEN) so release events behave consistently across both workflows.
+# `release: published`, which dispatches the pack pin (this tag) to
+# radius-project/radius as a reviewable sync PR. Radius records it under
+# `recipePacks[]` in deploy/manifest/defaults.yaml but does not vendor the pack;
+# its deploy workflows fetch the pack Bicep from here at deploy time. The
+# release is created with the RESOURCE_TYPES_BOT GitHub App token (not
+# GITHUB_TOKEN) precisely so that the `release: published` event is allowed to
+# trigger that downstream workflow.
 #
 # Prerequisite (one-time, admin): the RESOURCE_TYPES_BOT GitHub App must be
 # installed on this repository with `contents: write` so it can create the tag

--- a/Security/secrets/recipes/azure/terraform/main.tf
+++ b/Security/secrets/recipes/azure/terraform/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.0"
+      version = "~> 5.0"
     }
   }
 }
@@ -25,7 +25,7 @@ resource "azurerm_key_vault" "vault" {
   resource_group_name        = var.context.azure.resourceGroup.name
   tenant_id                  = data.azurerm_client_config.current.tenant_id
   sku_name                   = "standard"
-  enable_rbac_authorization  = false
+  rbac_authorization_enabled = false
   soft_delete_retention_days = 7
   purge_protection_enabled   = false
 

--- a/recipe-packs/kubernetes/README.md
+++ b/recipe-packs/kubernetes/README.md
@@ -10,7 +10,7 @@ Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map cont
 
 ## Recipes in this pack
 
-Kube-recipes tagged `:latest` are edge builds; released recipes are pinned to a version tag.
+Kube-recipes tagged `:edge` are rebuilt on every push to `main`; `:latest` and the version tags track stable releases.
 
 | Resource Type | Kind | Source |
 | --- | --- | --- |


### PR DESCRIPTION
<!--
Thank you for contributing to Radius! Please fill out each section below so
reviewers have the context they need. Sections marked optional can be removed
if they do not apply.
-->

## Summary

This pull request extends the repository's release and sync automation to support both resource-type namespaces and recipe packs as first-class units. The sync payload logic, helper libraries, and tests have been updated to detect, track, and emit changes for recipe packs alongside namespaces, enabling Radius to synchronize either or both types of units as needed. The payload and output formats are updated accordingly, and new test cases verify the correct behavior.

**Sync payload and logic enhancements:**

* The `.github/scripts/compute-radius-sync-payload.sh` script now tracks both namespaces and recipe packs as "units," updating all logic, payload structure, and outputs to include both types. This includes accurately detecting affected recipe packs on push and release events, and emitting them in the payload (`namespaces` and `recipe_packs` arrays). [[1]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deL23-R56) [[2]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deL59-R83) [[3]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deL95-R116) [[4]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deR125-R132) [[5]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deR141-R148) [[6]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deR176-R191) [[7]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deR208-R216) [[8]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deL164-R232) [[9]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deR256-R270) [[10]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deL213-R315) [[11]](diffhunk://#diff-2a11c16a136991c566fb5fc5e63a9121787b924aa30ece715910d717a67491deL244-R348)

**Shared library updates:**

* The `.github/scripts/lib-namespaces.sh` helper now provides functions for listing, identifying, and mapping recipe packs, making these available to both the sync payload and release tooling. Duplicated logic is removed from `release/lib.sh`. [[1]](diffhunk://#diff-1fd8b2639cac075e5b8de9a6c9ea230b6db9066ddf0d3c59d59feffb65e69de3L22-R36) [[2]](diffhunk://#diff-1fd8b2639cac075e5b8de9a6c9ea230b6db9066ddf0d3c59d59feffb65e69de3R131-R163) [[3]](diffhunk://#diff-57ada4665d7d28beb8c5fda0d578045e1c039287df428e4add55d88deb5ca8d8L47-L85)

**Testing improvements:**

* The test suite in `.github/scripts/tests/test-release-automation.sh` is expanded to cover recipe pack sync on both release and push events, as well as repo-wide releases affecting all units. Assertions verify both the payload structure and the correct identification of affected units.

## Reason for change

<!--
Explain why this change is needed. If it addresses a GitHub issue, link it
below so it is automatically closed when this PR merges (optional).
-->

Fixes #<!-- issue number (optional) -->

## How to test

<!-- Describe the steps a reviewer can take to verify these changes. -->

## File change summary

<!-- Summarize the change made in each file that was modified. -->

| File | Summary of change |
| ---- | ----------------- |
|      |                   |
