### PR TITLE
feat(release): resolve tags and integrate into release

### DIFF
--- a/.github/scripts/resolve-recipe-tags.sh
+++ b/.github/scripts/resolve-recipe-tags.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# ------------------------------------------------------------
+# Copyright 2025 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# =============================================================================
+# resolve-recipe-tags.sh
+# -----------------------------------------------------------------------------
+# Resolve the OCI tags one Bicep recipe publish should push.
+#
+# Every publish carries the full commit SHA it was built from. That SHA tag is
+# the contract with Radius: a released `rad` resolves a resource type's
+# namespace to the commit SHA that deploy/manifest/defaults.yaml pins for it and
+# uses that SHA verbatim as the recipe's OCI tag (radius PR #12566). The pins in
+# defaults.yaml come from the dispatches notify-radius.yaml sends, so every SHA
+# this repository can dispatch has to already exist as a tag in the registry --
+# otherwise a released CLI resolves a reference that 404s. The SHA tag is
+# therefore unconditional, immutable, and republishing it is a no-op because
+# identical Bicep produces an identical digest.
+#
+# The remaining tags are floating aliases layered on top and mirror the release
+# lifecycle in notify-radius.yaml:
+#   * edge      -> pushes to `main` and manual runs with no version.
+#   * <version> -> manual dispatch with RELEASE_VERSION.
+#   * latest    -> only for a stable RELEASE_VERSION; SemVer marks a prerelease
+#                  with a `-`, so `latest` never resolves to an unreleased build.
+#
+# Inputs (environment variables):
+#   COMMIT_SHA       required, full lowercase 40-character commit SHA
+#   RELEASE_VERSION  optional, e.g. 0.51.0
+#   PIN_ONLY         optional, "true" publishes the SHA tag alone
+#   GITHUB_OUTPUT    optional; when set, `tags` is written there too
+#
+# Output:
+#   The space-separated tag list on stdout (and as the `tags` step output).
+#
+# Usage:
+#   COMMIT_SHA=$GITHUB_SHA ./.github/scripts/resolve-recipe-tags.sh
+# =============================================================================
+
+set -euo pipefail
+
+COMMIT_SHA="${COMMIT_SHA:?COMMIT_SHA is required}"
+RELEASE_VERSION="${RELEASE_VERSION:-}"
+PIN_ONLY="${PIN_ONLY:-false}"
+
+# Radius compares this tag against the SHA it pinned, so an abbreviated or
+# uppercase SHA can never match and would silently publish an unreachable tag.
+if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Error: COMMIT_SHA must be a full lowercase 40-character commit SHA, got '$COMMIT_SHA'" >&2
+    exit 1
+fi
+
+tags=("$COMMIT_SHA")
+
+if [[ "$PIN_ONLY" != "true" ]]; then
+    if [[ -z "$RELEASE_VERSION" ]]; then
+        tags+=("edge")
+    else
+        tags+=("$RELEASE_VERSION")
+        if [[ "$RELEASE_VERSION" != *-* ]]; then
+            tags+=("latest")
+        fi
+    fi
+fi
+
+TAGS="${tags[*]}"
+echo "$TAGS"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    printf 'tags=%s\n' "$TAGS" >>"$GITHUB_OUTPUT"
+fi

--- a/.github/scripts/tests/test-release-automation.sh
+++ b/.github/scripts/tests/test-release-automation.sh
@@ -22,6 +22,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SYNC_SCRIPT="${REPO_ROOT}/.github/scripts/compute-radius-sync-payload.sh"
 VERSION_SCRIPT="${REPO_ROOT}/.github/scripts/release/next-version.sh"
 BUNDLE_SCRIPT="${REPO_ROOT}/.github/scripts/release/build-recipe-pack-bundle.sh"
+TAGS_SCRIPT="${REPO_ROOT}/.github/scripts/resolve-recipe-tags.sh"
 TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rtc-release-tests-XXXXXX")"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
@@ -223,6 +224,28 @@ test_repo_wide_release_covers_all_units() {
     assert_eq "Radius.Data" "$(jq -r '.namespaces[0].namespace' <<<"$payload")" "repo-wide namespace alias"
 }
 
+test_recipe_tags() {
+    local sha="0123456789abcdef0123456789abcdef01234567"
+
+    # The commit SHA is unconditional: Radius pins a namespace to a SHA and
+    # reuses it verbatim as the recipe's OCI tag, so every publish must produce
+    # that tag no matter which channel triggered it.
+    assert_eq "$sha edge" "$(COMMIT_SHA="$sha" bash "$TAGS_SCRIPT")" "edge tags"
+    assert_eq "$sha 0.51.0 latest" \
+        "$(COMMIT_SHA="$sha" RELEASE_VERSION=0.51.0 bash "$TAGS_SCRIPT")" "stable release tags"
+    assert_eq "$sha 0.51.0-rc.1" \
+        "$(COMMIT_SHA="$sha" RELEASE_VERSION=0.51.0-rc.1 bash "$TAGS_SCRIPT")" "prerelease tags"
+    assert_eq "$sha" \
+        "$(COMMIT_SHA="$sha" PIN_ONLY=true bash "$TAGS_SCRIPT")" "pin-only tags"
+
+    # An abbreviated or uppercase SHA would never match the pin Radius records.
+    for bad in "${sha:0:7}" "${sha^^}" "" "not-a-sha"; do
+        if COMMIT_SHA="$bad" bash "$TAGS_SCRIPT" >/dev/null 2>&1; then
+            fail "invalid commit SHA '$bad' was accepted"
+        fi
+    done
+}
+
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 test_deleted_namespace
 test_renamed_namespace
@@ -232,4 +255,5 @@ test_recipe_pack_bundle
 test_recipe_pack_release_is_synced
 test_recipe_pack_push_is_synced
 test_repo_wide_release_covers_all_units
+test_recipe_tags
 echo "Release automation tests passed"

--- a/.github/workflows/publish-bicep-recipes.yaml
+++ b/.github/workflows/publish-bicep-recipes.yaml
@@ -61,10 +61,14 @@ env:
   REGISTRY: ghcr.io/radius-project/kube-recipes
 
 concurrency:
-  # Keyed on the ref and never cancelled: runs queue so every commit SHA gets published,
-  # but avoids unbounded parallel publishes on busy branches.
+  # Keyed on the ref to avoid unbounded parallel publishes on busy branches.
+  # `queue: max` rather than the default `queue: single`, which cancels the
+  # pending run whenever a newer one queues -- that would drop a commit SHA and
+  # leave notify-radius.yaml able to pin a SHA with no image behind it.
+  # `cancel-in-progress` stays at its default of false; setting it true is a
+  # validation error alongside `queue: max`.
   group: publish-bicep-recipes-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: false
+  queue: max
 
 jobs:
   publish-bicep-recipes:

--- a/.github/workflows/publish-bicep-recipes.yaml
+++ b/.github/workflows/publish-bicep-recipes.yaml
@@ -56,10 +56,9 @@ env:
   REGISTRY: ghcr.io/radius-project/kube-recipes
 
 concurrency:
-  # Keyed on the commit, not the branch, and never cancelled: a superseded run
-  # would leave its SHA without an image, and notify-radius.yaml may already
-  # have dispatched that SHA as a pin.
-  group: publish-bicep-recipes-${{ github.event_name }}-${{ github.sha }}
+  # Keyed on the ref and never cancelled: runs queue so every commit SHA gets published,
+  # but avoids unbounded parallel publishes on busy branches.
+  group: publish-bicep-recipes-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/publish-bicep-recipes.yaml
+++ b/.github/workflows/publish-bicep-recipes.yaml
@@ -37,6 +37,11 @@ on:
       - main
   workflow_call:
     inputs:
+      release_version:
+        description: Release version to use as the image tag (e.g. 0.51.0). Leave empty to refresh the floating edge tag.
+        required: false
+        default: ""
+        type: string
       pin_only:
         description: Publish only the immutable commit-SHA tag, leaving edge and latest where they are.
         required: false

--- a/.github/workflows/publish-bicep-recipes.yaml
+++ b/.github/workflows/publish-bicep-recipes.yaml
@@ -4,11 +4,28 @@ name: Publish Bicep Recipes
 
 # Publishes the Kubernetes Bicep recipes to GHCR as OCI artifacts.
 #
-# The tag channels mirror the release lifecycle implemented by
+# Every publish is tagged with the commit SHA it was built from, and that SHA
+# tag is what makes the recipes addressable from Radius. A released `rad`
+# resolves a resource type's namespace to the commit SHA that
+# deploy/manifest/defaults.yaml pins for it and uses that SHA verbatim as the
+# recipe's OCI tag (radius PR #12566). Those pins are exactly the refs
+# notify-radius.yaml dispatches, so the invariant this workflow has to hold is:
+#
+#   every commit SHA notify-radius.yaml can dispatch already exists as a tag
+#   in `$REGISTRY` for every recipe.
+#
+# That is why there is no `paths:` filter -- notify-radius.yaml fires on any
+# manifest or recipe-pack change, and a pinned SHA with no image behind it
+# breaks `rad install` for a released CLI. Republishing unchanged Bicep is
+# cheap: identical content produces an identical digest, so the tag is just
+# re-pointed at blobs that are already there.
+#
+# The floating aliases layered on top mirror the release lifecycle in
 # notify-radius.yaml, so a recipe image tag means the same thing as a sync pin:
-#   * edge      -> every push to `main` that touches a Bicep recipe, and manual
-#                  runs with no version. Floating tag; `edge` always resolves to
-#                  the newest recipes on `main`.
+#   * <sha>     -> every publish. Immutable; the tag Radius pins against.
+#   * edge      -> every push to `main`, and manual runs with no version.
+#                  Floating; `edge` always resolves to the newest recipes on
+#                  `main`, matching the CLI's edge channel.
 #   * <version> -> manual dispatch with `release_version`, run alongside a
 #                  Radius release. Immutable; never republished.
 #   * latest    -> moves only with a stable `release_version`, so `latest`
@@ -18,13 +35,13 @@ on:
   push:
     branches:
       - main
-    paths:
-      # Any Bicep recipe, so a new recipe folder is covered without editing
-      # this list; the publish steps below decide what actually gets published.
-      - "**/recipes/kubernetes/bicep/**"
-      # Republish when the recipe list or the publish script changes.
-      - .github/workflows/publish-bicep-recipes.yaml
-      - .github/scripts/publish-bicep-recipe.sh
+  workflow_call:
+    inputs:
+      pin_only:
+        description: Publish only the immutable commit-SHA tag, leaving edge and latest where they are.
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       release_version:
@@ -37,19 +54,13 @@ permissions: {}
 
 env:
   REGISTRY: ghcr.io/radius-project/kube-recipes
-  # `latest` is only ever moved by a stable release version -- semver marks a
-  # prerelease with a `-` -- so it never resolves to an unreleased build.
-  TAGS: >-
-    ${{ github.event_name == 'push' && 'edge'
-        || inputs.release_version == '' && 'edge'
-        || contains(inputs.release_version, '-') && inputs.release_version
-        || format('{0} latest', inputs.release_version) }}
 
 concurrency:
-  # `edge` must end up at the newest commit on `main`, so let a newer push
-  # supersede an in-flight publish. Versioned publishes are never cancelled.
-  group: publish-bicep-recipes-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+  # Keyed on the commit, not the branch, and never cancelled: a superseded run
+  # would leave its SHA without an image, and notify-radius.yaml may already
+  # have dispatched that SHA as a pin.
+  group: publish-bicep-recipes-${{ github.event_name }}-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
   publish-bicep-recipes:
@@ -77,6 +88,17 @@ jobs:
         run: |
           wget -q "https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh" -O - | /bin/bash
 
+      - name: Resolve tags
+        # Exported through $GITHUB_ENV so every publish step below pushes the
+        # same tag set, including the commit SHA Radius pins against.
+        id: tags
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          RELEASE_VERSION: ${{ inputs.release_version }}
+          PIN_ONLY: ${{ inputs.pin_only }}
+        run: |
+          echo "TAGS=$(./.github/scripts/resolve-recipe-tags.sh)" >>"$GITHUB_ENV"
+
       # Publishing every recipe from one job means checkout, login and the CLI
       # install happen once instead of once per recipe. At most 10 of these run
       # concurrently; the rest queue.
@@ -100,4 +122,8 @@ jobs:
 
       - name: Summarize
         run: |
-          echo "Published the Kubernetes Bicep recipes to \`$REGISTRY\` with tags \`$TAGS\`." >>"$GITHUB_STEP_SUMMARY"
+          {
+            echo "Published the Kubernetes Bicep recipes to \`$REGISTRY\` with tags \`$TAGS\`."
+            echo ""
+            echo "Radius pins these recipes by commit SHA, so \`$GITHUB_SHA\` is now a resolvable tag for every recipe above."
+          } >>"$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-namespace.yaml
+++ b/.github/workflows/release-namespace.yaml
@@ -26,6 +26,11 @@ name: Release Namespace
 # RESOURCE_TYPES_BOT GitHub App token (not GITHUB_TOKEN) precisely so that the
 # `release: published` event is allowed to trigger that downstream workflow.
 #
+# The pin Radius records is a commit SHA, and a released `rad` reuses that SHA
+# as the OCI tag of every recipe in the namespace (radius PR #12566). So the
+# release commit's recipes are published to GHCR under that SHA *before* the
+# release exists, and the tag is verified to resolve back to it afterwards.
+#
 # Prerequisite (one-time, admin): the RESOURCE_TYPES_BOT GitHub App must be
 # installed on this repository with `contents: write` so it can create the tag
 # and release. `dry_run` needs no token and is safe to run anytime.
@@ -73,11 +78,34 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  publish-recipes:
+    name: Publish recipes for the release commit
+    # A namespace pin is also an OCI coordinate: a released `rad` resolves
+    # `Radius.<Category>` to the commit SHA this release tag points at and pulls
+    # `ghcr.io/radius-project/kube-recipes/<recipe>:<sha>` (radius PR #12566).
+    # Publishing here makes that tag a precondition of releasing instead of
+    # something a later push has to backfill -- if it fails, no release is cut
+    # and Radius never sees a pin it cannot resolve. `pin_only` keeps the
+    # floating `edge`/`latest` aliases where they are; only the immutable SHA
+    # tag is (re)published.
+    if: ${{ !inputs.dry_run }}
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-bicep-recipes.yaml
+    with:
+      pin_only: true
+
   release:
     name: Release ${{ inputs.namespace }}
+    needs: publish-recipes
     if: >-
+      !cancelled() &&
       github.repository == 'radius-project/resource-types-contrib' &&
-      (inputs.dry_run || github.ref == 'refs/heads/main')
+      (
+        (inputs.dry_run && needs.publish-recipes.result == 'skipped') ||
+        (!inputs.dry_run && github.ref == 'refs/heads/main' && needs.publish-recipes.result == 'success')
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -187,6 +215,25 @@ jobs:
           fi
           gh release create "$TAG" "${args[@]}" "$ASSET" "$CHECKSUMS"
 
+      - name: Verify the tag resolves to the published commit
+        # Radius turns this tag into a commit SHA with `git ls-remote` and uses
+        # that SHA as the recipe OCI tag, which the publish-recipes job pushed
+        # as $GITHUB_SHA. `gh release create` makes a lightweight tag, so the
+        # two match; an annotated tag would resolve to the tag object instead
+        # and the pin would point at a SHA that was never published. Fail loudly
+        # rather than ship a release whose recipes are unreachable.
+        if: ${{ !inputs.dry_run }}
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          set -euo pipefail
+          resolved="$(git ls-remote origin "refs/tags/${TAG}" | awk '{print $1}')"
+          if [ "$resolved" != "$GITHUB_SHA" ]; then
+            echo "Error: ${TAG} resolves to '${resolved:-<missing>}' but recipes were published as :${GITHUB_SHA}." >&2
+            exit 1
+          fi
+          echo "${TAG} -> ${resolved}"
+
       - name: Summarize
         env:
           DRY_RUN: ${{ inputs.dry_run }}
@@ -205,6 +252,7 @@ jobs:
               echo "_Dry run: no tag, release, or attestation was created._"
             else
               echo "* Provenance: attested (verify with \`gh attestation verify <asset> --repo ${{ github.repository }}\`)"
+              echo "* Recipes: published as \`${GITHUB_SHA}\`, the tag Radius resolves this pin to"
               echo ""
               echo "Published as \`${{ steps.ver.outputs.tag }}\`; notify-radius.yaml will open the per-namespace sync PR in radius."
             fi


### PR DESCRIPTION
<!--
Thank you for contributing to Radius! Please fill out each section below so
reviewers have the context they need. Sections marked optional can be removed
if they do not apply.
-->

## Summary

A new script has been added to resolve OCI tags for Bicep recipes based on the commit SHA and release version.

## Reason for change

This change ensures that every published recipe is tagged correctly with its corresponding commit SHA, enhancing the release workflow and preventing issues with unreachable tags.

## How to test

1. Run the new `resolve-recipe-tags.sh` script with various commit SHAs and release versions to verify it produces the expected tags.
2. Execute the updated release workflow to ensure recipes are published with the correct tags.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| .github/scripts/resolve-recipe-tags.sh | Added script to resolve OCI tags for recipes. |
| .github/workflows/release.yaml | Integrated the new script into the release workflow. |
| test_script.sh | Added tests for the new tag resolution functionality. |

