### PR TITLE
Fix Kubernetes names for camelCase containers

### DIFF
--- a/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+++ b/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
@@ -128,7 +128,7 @@ var containerSpecs = reduce(containerItems, [], (acc, item) => concat(acc, [{
     // Add ports if they exist
     contains(item.value, 'ports') ? {
       ports: reduce(items(item.value.ports), [], (portAcc, port) => concat(portAcc, [{
-        name: port.key
+        name: toLower(port.key)
         containerPort: port.value.containerPort
         protocol: port.value.?protocol ?? 'TCP'
       }]))
@@ -176,7 +176,7 @@ var containerSpecs = reduce(containerItems, [], (acc, item) => concat(acc, [{
     // Add volume mounts if they exist
     contains(item.value, 'volumeMounts') ? {
       volumeMounts: reduce(item.value.volumeMounts, [], (vmAcc, vm) => concat(vmAcc, [{
-        name: vm.volumeName
+        name: toLower(vm.volumeName)
         mountPath: vm.mountPath
       }]))
     } : {},
@@ -263,7 +263,7 @@ var podInitContainers = reduce(containerSpecs, [], (acc, container) => (containe
 var volumeItems = items(resourceProperties.?volumes ?? {})
 var podVolumes = reduce(volumeItems, [], (acc, vol) => concat(acc, [union(
   {
-    name: vol.key
+    name: toLower(vol.key)
   },
   contains(vol.value, 'persistentVolume') ? {
     persistentVolumeClaim: {
@@ -326,7 +326,7 @@ var servicesConfig = reduce(containerItems, [], (acc, item) =>
     containerName: item.key
     normalizedContainerName: toLower(item.key)
     ports: reduce(items(item.value.ports), [], (portAcc, port) => concat(portAcc, [{
-      name: port.key
+      name: toLower(port.key)
       port: port.value.containerPort
       targetPort: port.value.containerPort
       protocol: port.value.?protocol ?? 'TCP'

--- a/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
+++ b/Compute/containers/recipes/kubernetes/bicep/kubernetes-containers.bicep
@@ -8,7 +8,7 @@ extension kubernetes with {
 
 var resourceName = context.resource.name
 var namespace = context.runtime.kubernetes.namespace
-var normalizedName = resourceName
+var normalizedName = toLower(resourceName)
 
 var resourceProperties = context.resource.?properties ?? {}
 var containerItems = items(resourceProperties.?containers ?? {})
@@ -122,7 +122,7 @@ var containerSpecs = reduce(containerItems, [], (acc, item) => concat(acc, [{
   isInit: item.value.?initContainer ?? false
   spec: union(
     {
-      name: item.key
+      name: toLower(item.key)
       image: item.value.image
     },
     // Add ports if they exist
@@ -324,6 +324,7 @@ resource deployment 'apps/Deployment@v1' = {
 var servicesConfig = reduce(containerItems, [], (acc, item) => 
   contains(item.value, 'ports') && length(items(item.value.ports)) > 0 ? concat(acc, [{
     containerName: item.key
+    normalizedContainerName: toLower(item.key)
     ports: reduce(items(item.value.ports), [], (portAcc, port) => concat(portAcc, [{
       name: port.key
       port: port.value.containerPort
@@ -335,7 +336,7 @@ var servicesConfig = reduce(containerItems, [], (acc, item) =>
 
 resource services 'core/Service@v1' = [for svc in servicesConfig: {
   metadata: {
-    name: '${normalizedName}-${svc.containerName}'
+    name: '${normalizedName}-${svc.normalizedContainerName}'
     namespace: namespace
     labels: union(labels, {
       container: svc.containerName
@@ -408,7 +409,7 @@ resource hpa 'autoscaling/HorizontalPodAutoscaler@v2' = if (hasAutoScaling) {
 }
 
 var deploymentResource = '/planes/kubernetes/local/namespaces/${namespace}/providers/apps/Deployment/${normalizedName}'
-var serviceResources = reduce(servicesConfig, [], (acc, svc) => concat(acc, ['/planes/kubernetes/local/namespaces/${namespace}/providers/core/Service/${normalizedName}-${svc.containerName}']))
+var serviceResources = reduce(servicesConfig, [], (acc, svc) => concat(acc, ['/planes/kubernetes/local/namespaces/${namespace}/providers/core/Service/${normalizedName}-${svc.normalizedContainerName}']))
 var hpaResource = hasAutoScaling ? ['/planes/kubernetes/local/namespaces/${namespace}/providers/autoscaling/HorizontalPodAutoscaler/${normalizedName}'] : []
 
 var allResources = concat([deploymentResource], serviceResources, hpaResource)

--- a/Compute/containers/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containers/recipes/kubernetes/terraform/main.tf
@@ -14,7 +14,7 @@ terraform {
 locals {
   resource_name   = var.context.resource.name
   namespace       = var.context.runtime.kubernetes.namespace
-  normalized_name = local.resource_name
+  normalized_name = lower(local.resource_name)
 
   # Extract resource properties
   resource_properties = try(var.context.resource.properties, {})
@@ -141,7 +141,7 @@ locals {
   container_specs = {
     for name, config in local.containers : name => {
       is_init     = try(config.initContainer, false)
-      name        = name
+      name        = lower(name)
       image       = config.image
       command     = try(config.command, null)
       args        = try(config.args, null)
@@ -253,8 +253,9 @@ locals {
   # Build services config - one service per container with ports
   services_config = {
     for name, spec in local.regular_container_specs : name => {
-      container_name = name
-      ports          = spec.ports
+      container_name          = spec.name
+      original_container_name = name
+      ports                   = spec.ports
     }
     if length(spec.ports) > 0
   }
@@ -624,7 +625,7 @@ resource "kubernetes_service" "services" {
     name      = "${local.normalized_name}-${each.value.container_name}"
     namespace = local.namespace
     labels = merge(local.labels, {
-      container = each.value.container_name
+      container = each.value.original_container_name
     })
   }
 

--- a/Compute/containers/recipes/kubernetes/terraform/main.tf
+++ b/Compute/containers/recipes/kubernetes/terraform/main.tf
@@ -150,7 +150,7 @@ locals {
       # Ports
       ports = [
         for port_name, port_config in try(config.ports, {}) : {
-          name           = port_name
+          name           = lower(port_name)
           container_port = port_config.containerPort
           protocol       = try(port_config.protocol, "TCP")
         }
@@ -181,7 +181,7 @@ locals {
       # Volume mounts
       volume_mounts = [
         for vm in try(config.volumeMounts, []) : {
-          name       = vm.volumeName
+          name       = lower(vm.volumeName)
           mount_path = vm.mountPath
         }
       ]
@@ -224,7 +224,7 @@ locals {
 locals {
   volume_specs = [
     for vol_name, vol_config in local.volumes : {
-      name = vol_name
+      name = lower(vol_name)
 
       # Persistent Volume Claim - extract PVC name from resourceId (last segment of the path)
       persistent_volume_claim = try(vol_config.persistentVolume, null) != null ? {

--- a/Compute/containers/test/app.bicep
+++ b/Compute/containers/test/app.bicep
@@ -19,7 +19,7 @@ resource app 'Radius.Core/applications@2025-08-01-preview' = {
 
 // Create a container that mounts the persistent volume
 resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
-  name: 'myapp'
+  name: 'myApp'
   properties: {
     environment: environment
     application: app.id
@@ -34,7 +34,7 @@ resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
       }
     }
     containers: {
-      web: {
+      orderProcessor: {
         image: 'nginx:alpine'
         command: ['/bin/sh', '-c']
         args: ['nginx -g "daemon off;"']
@@ -116,7 +116,7 @@ resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
           periodSeconds: 10
         }
       }
-      init: {
+      dbMigration: {
         initContainer: true
         image: 'busybox:latest'
         command: ['sh', '-c']

--- a/Compute/containers/test/app.bicep
+++ b/Compute/containers/test/app.bicep
@@ -40,7 +40,7 @@ resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         args: ['nginx -g "daemon off;"']
         workingDir: '/usr/share/nginx/html'
         ports: {
-          http: {
+          httpPort: {
             containerPort: 80
             protocol: 'TCP'
           }
@@ -73,15 +73,15 @@ resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         }
         volumeMounts: [
           {
-            volumeName: 'data'
+            volumeName: 'appData'
             mountPath: '/app/data'
           }
           {
-            volumeName: 'cache'
+            volumeName: 'cacheData'
             mountPath: '/tmp/cache'
           }
           {
-            volumeName: 'secrets'
+            volumeName: 'appSecrets'
             mountPath: '/etc/secrets'
           }
         ] 
@@ -137,18 +137,18 @@ resource myContainer 'Radius.Compute/containers@2025-08-01-preview' = {
     }
     restartPolicy: 'Always'
     volumes: {
-      data: {
+      appData: {
         persistentVolume: {
           resourceId: myPersistentVolume.id
           accessMode: 'ReadWriteOnce'
         }
       }
-      cache: {
+      cacheData: {
         emptyDir: {
           medium: 'memory'
         }
       }
-      secrets: {
+      appSecrets: {
         secretName: secret.name
       }
     }


### PR DESCRIPTION
## Summary

Radius accepts camelCase names, but Kubernetes rejects them as RFC 1123 identifiers. This change lowercases Kubernetes-facing resource and container names in both recipes while preserving the original Radius names in configuration and labels.

## Validation

- Deployed the fixture through the Bicep and Terraform recipes.
- Confirmed normalized output resource IDs remove the generated Kubernetes resources.

Fixes #257
