### PR TITLE
Add spellcheck Make target

### DIFF
--- a/.github/build/lint.mk
+++ b/.github/build/lint.mk
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------
+# Copyright 2025 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+##@ Linting
+
+.PHONY: install-cspell
+install-cspell: ## Install cspell globally via npm (requires Node.js/npm).
+	@command -v npm >/dev/null 2>&1 || { echo "npm (Node.js) is required to install cspell. Install Node.js $$(cat .node-version 2>/dev/null || echo 24), then retry."; exit 1; }
+	@echo -e "$(ARROW) Installing cspell..."
+	@npm install -g cspell
+
+.PHONY: spellcheck
+spellcheck: ## Run cspell over Markdown and YAML docs (matches the Spellcheck CI workflow). Installs cspell if missing.
+	@command -v cspell >/dev/null 2>&1 || $(MAKE) install-cspell
+	@echo -e "$(ARROW) Running spellcheck..."
+	@cspell lint --config ./.github/linters/.cspell.yml --no-progress --dot "**/*.{md,yaml,yml}"

--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ SHELL := /bin/bash
 ARROW := \033[34;1m=>\033[0m
 
 # order matters for these
-include ./.github/build/help.mk ./.github/build/environment.mk ./.github/build/test.mk ./.github/build/release.mk
+include ./.github/build/help.mk ./.github/build/environment.mk ./.github/build/test.mk ./.github/build/release.mk ./.github/build/lint.mk


### PR DESCRIPTION
Follow-on to #272, which added the CI Spellcheck workflow for Markdown and YAML files.

## Summary

- add a `make spellcheck` target that runs the same cspell command as CI
- install cspell globally through npm when it is not already available
- expose the spellcheck targets in `make help`

## Testing

- `make help`
- `make spellcheck` (62 files checked, 0 issues)
- confirmed Make recipe lines use tab indentation

Radius application graph diff generation was unavailable because this repository has no Dockerfile or `.radius/app.bicep`; the Radius app modeling skill does not support generating an application model without a Dockerfile.