### PR TITLE
Fix postgreSqlDatabases Azure recipe to forward server configurations (azure.extensions)

### DIFF
--- a/.cspellignore
+++ b/.cspellignore
@@ -10,6 +10,7 @@ MYSQLDB
 oras
 ORAS
 PGDATA
+pgvector
 rrttest
 SLSA
 tmpfs

--- a/Data/postgreSqlDatabases/README.md
+++ b/Data/postgreSqlDatabases/README.md
@@ -26,7 +26,7 @@ Recipes for this resource type are provided through the platform Recipe Packs at
 
 | Platform | Recipe Pack | Recipe source |
 | --- | --- | --- |
-| Azure | [`recipe-packs/azure/bicep-recipepack.bicep`](../../recipe-packs/azure/bicep-recipepack.bicep) | Direct module — Azure Verified Module `avm/res/db-for-postgre-sql/flexible-server` |
+| Azure | [`recipe-packs/azure/aks-recipepack.bicep`](../../recipe-packs/azure/aks-recipepack.bicep) | Direct module — Azure Verified Module `avm/res/db-for-postgre-sql/flexible-server` |
 
 ## Using the resource type
 

--- a/recipe-packs/azure/README.md
+++ b/recipe-packs/azure/README.md
@@ -4,7 +4,7 @@ This folder contains the **Azure Recipe Pack** — a collection of Recipes that 
 
 | File | Description |
 | --- | --- |
-| `bicep-recipepack.bicep` | Recipe Pack wiring the Bicep recipes for all Azure-provisioned types, plus the Environment definition. |
+| `aks-recipepack.bicep` | Recipe Pack wiring the Bicep recipes for all Azure-provisioned types, plus the Environment definition. |
 
 Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, and a `Radius.Core/environments` resource that references the pack and configures the Azure provider.
 
@@ -42,6 +42,7 @@ The Azure pack accepts the provider configuration it needs to provision into you
 | `routesGatewayNamespace` | Namespace of the Gateway resource for `Radius.Compute/routes`. Defaults to `default`. |
 | `containerImagesRegistry` | Registry path (e.g. `ghcr.io/my-org`) that `Radius.Compute/containerImages` pushes built images to. |
 | `containerImagesRegistrySecretName` | Name of the Kubernetes Secret holding registry credentials for `Radius.Compute/containerImages`. Optional; leave empty for an unauthenticated registry. |
+| `postgreSqlServerConfigurations` | Server parameters forwarded verbatim to the AVM PostgreSQL flexible server `configurations` array for `Radius.Data/postgreSqlDatabases`, using the AVM item shape `{ name, source, value }`. Most commonly used to allow-list extensions via `azure.extensions` — for example `[{ name: 'azure.extensions', source: 'user-override', value: 'vector' }]` to enable pgvector. Optional; defaults to an empty array (no extra server configuration). |
 
 ## Deploying
 

--- a/recipe-packs/azure/README.md
+++ b/recipe-packs/azure/README.md
@@ -42,7 +42,7 @@ The Azure pack accepts the provider configuration it needs to provision into you
 | `routesGatewayNamespace` | Namespace of the Gateway resource for `Radius.Compute/routes`. Defaults to `default`. |
 | `containerImagesRegistry` | Registry path (e.g. `ghcr.io/my-org`) that `Radius.Compute/containerImages` pushes built images to. |
 | `containerImagesRegistrySecretName` | Name of the Kubernetes Secret holding registry credentials for `Radius.Compute/containerImages`. Optional; leave empty for an unauthenticated registry. |
-| `postgreSqlServerConfigurations` | Server parameters forwarded verbatim to the AVM PostgreSQL flexible server `configurations` array for `Radius.Data/postgreSqlDatabases`, using the AVM item shape `{ name, source, value }`. Most commonly used to allow-list extensions via `azure.extensions` — for example `[{ name: 'azure.extensions', source: 'user-override', value: 'vector' }]` to enable pgvector. Optional; defaults to an empty array (no extra server configuration). |
+| `postgreSqlServerConfigurations` | Server parameters forwarded verbatim to the AVM PostgreSQL flexible server `configurations` array for `Radius.Data/postgreSqlDatabases`, using the AVM item shape `{ name, source, value }`. Most commonly used to allow-list extensions via `azure.extensions` — for example `[{ name: 'azure.extensions', source: 'user-override', value: 'vector' }]` to enable pgvector. See [Extensions and modules by name in Azure Database for PostgreSQL flexible server](https://learn.microsoft.com/en-us/azure/postgresql/extensions/concepts-extensions-versions) for the supported extension names. Optional; defaults to an empty array (no extra server configuration). |
 
 ## Deploying
 

--- a/recipe-packs/azure/aks-recipepack.bicep
+++ b/recipe-packs/azure/aks-recipepack.bicep
@@ -24,6 +24,9 @@ param containerImagesRegistry string
 @description('Name of the Kubernetes Secret holding registry credentials for Radius.Compute/containerImages. Leave empty for an unauthenticated registry.')
 param containerImagesRegistrySecretName string = ''
 
+@description('Server parameters forwarded verbatim to the AVM PostgreSQL flexible server `configurations` array for Radius.Data/postgreSqlDatabases. Use the AVM item shape `{ name, source, value }`. Most commonly used to allow-list extensions via the `azure.extensions` parameter, for example `[{ name: \'azure.extensions\', source: \'user-override\', value: \'vector\' }]` to enable pgvector. Defaults to an empty array (no extra server configuration).')
+param postgreSqlServerConfigurations array = []
+
 resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
   name: 'azure-avm'
   properties: {
@@ -211,6 +214,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
           lock: {
             kind: 'None'
           }
+          configurations: postgreSqlServerConfigurations
         }
         outputs: {
           host: 'fqdn'

--- a/recipe-packs/azure/aks-recipepack.bicep
+++ b/recipe-packs/azure/aks-recipepack.bicep
@@ -24,7 +24,7 @@ param containerImagesRegistry string
 @description('Name of the Kubernetes Secret holding registry credentials for Radius.Compute/containerImages. Leave empty for an unauthenticated registry.')
 param containerImagesRegistrySecretName string = ''
 
-@description('Server parameters forwarded verbatim to the AVM PostgreSQL flexible server `configurations` array for Radius.Data/postgreSqlDatabases. Use the AVM item shape `{ name, source, value }`. Most commonly used to allow-list extensions via the `azure.extensions` parameter, for example `[{ name: \'azure.extensions\', source: \'user-override\', value: \'vector\' }]` to enable pgvector. Defaults to an empty array (no extra server configuration).')
+@description('Server parameters forwarded verbatim to the AVM PostgreSQL flexible server configurations array for Radius.Data/postgreSqlDatabases, using the AVM item shape with name, source, and value fields. Commonly used to allow-list extensions via the azure.extensions parameter (for example to enable pgvector). See recipe-packs/azure/README.md for an example and a link to the supported extensions. Defaults to an empty array (no extra server configuration).')
 param postgreSqlServerConfigurations array = []
 
 resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {


### PR DESCRIPTION
## Summary

Fixes #258.

The Azure recipe for `Radius.Data/postgreSqlDatabases` (inline in `recipe-packs/azure/aks-recipepack.bicep`) calls the AVM module `avm/res/db-for-postgre-sql/flexible-server:0.15.2` but never passes the module's `configurations` array. `configurations` is how the AVM module creates `Microsoft.DBforPostgreSQL/flexibleServers/configurations`, including the `azure.extensions` allow-list. Because the recipe omitted it, apps needing a Postgres extension (pgvector, postgis, ...) could not allow-list it and their startup migration failed with:

> extension "vector" is not allow-listed for "azure_pg_admin" users in Azure Database for PostgreSQL

This is a recipe defect, not a type-schema gap — the `postgreSqlDatabases` resource type is intentionally not modified.

## Changes

- `recipe-packs/azure/aks-recipepack.bicep`: added a pack-level `param postgreSqlServerConfigurations array = []` and forwarded it verbatim to the Postgres recipe's AVM module via `configurations: postgreSqlServerConfigurations`. The parameter uses the AVM `configurations` item shape (`{ name, source, value }`) so it is passed straight through with no parsing or curated defaults. Default `[]` preserves current behavior when unset.
- `recipe-packs/azure/README.md`: documented `postgreSqlServerConfigurations` in the Parameters table with a pgvector example and a link to the [supported extensions list](https://learn.microsoft.com/en-us/azure/postgresql/extensions/concepts-extensions-versions), and fixed a stale `bicep-recipepack.bicep` reference (actual file is `aks-recipepack.bicep`).
- `Data/postgreSqlDatabases/README.md`: fixed the same stale `bicep-recipepack.bicep` reference.

## Usage

A platform engineer enables an extension when deploying the pack, e.g.:

```bicep
postgreSqlServerConfigurations: [
  { name: 'azure.extensions', source: 'user-override', value: 'vector' }
]
```

See [Extensions and modules by name in Azure Database for PostgreSQL flexible server](https://learn.microsoft.com/en-us/azure/postgresql/extensions/concepts-extensions-versions) for the supported extension names.

## Testing

- **Compile check (done):** compiled `recipe-packs/azure/aks-recipepack.bicep` with the Radius-bundled bicep (`~/.rad/bin/bicep`, v0.41.2). Exit 0, no errors — only pre-existing informational `BCP081` warnings for the Radius extension types (unrelated to this change).
- **Full Radius E2E (done — PASS):** on a local kind cluster running the Radius control plane, with an Azure service principal credential, the real recipe was executed end to end:
  1. Registered a `Radius.Core/recipePacks` (`azure-avm`) containing the **fixed** Postgres recipe (`configurations: [{ name: 'azure.extensions', source: 'user-override', value: 'vector' }]`) → `Succeeded`.
  2. Registered `Radius.Core/environments/default` with the Azure provider + that recipe pack.
  3. Created `Radius.Data/postgreSqlDatabases/pgext258` → dynamic-rp executed the recipe and provisioned a real Azure flexible server → `Succeeded`; `outputResources` include `.../flexibleServers/pgext258/configurations/azure.extensions`.
  - `az postgres flexible-server parameter show --name azure.extensions` on the Radius-provisioned server → `value: vector`, `source: user-override`.
  - `CREATE EXTENSION vector;` via psql succeeded (`vector` 0.8.2 in `pg_extension`).
  - This confirms the `configurations: postgreSqlServerConfigurations` passthrough works through the actual Radius recipe engine, not just the AVM module in isolation.
- **Direct AVM E2E (done — PASS):** independently, the same AVM module version (`0.15.2`) was deployed via `az deployment group create` with the identical `configurations` array, reproducing the same result (`azure.extensions=vector`, `CREATE EXTENSION vector` succeeds) — isolating the module behavior the fix relies on.
- **Back-compat:** with the default empty array the module receives `configurations: []`, so no configuration child resources are created and `azure.extensions` stays at its system default — no regression for callers that don't set it.
- **Why not the standard CI harness:** the automated Azure recipe tests (`validate-azure-recipes.yaml`) generate a pack from per-type `recipes/<platform>/bicep` folders and drive `test/app.bicep` via resource **properties** only — they never set recipe-pack parameters, and this curated pack is not deployed by any CI job. A pack parameter therefore cannot be exercised by the current automated harness without adding a type-schema property (out of scope by design), so the manual E2E above is the validation of record.

## Out of scope

- No new property on `Radius.Data/postgreSqlDatabases` (type schema untouched).
- Kubernetes recipes unchanged.