### PR TITLE
feat(release): add change detection for namespaces and recipe packs

### DIFF
--- a/.github/build/release.mk
+++ b/.github/build/release.mk
@@ -47,6 +47,16 @@ ifneq ($(and $(strip $(NAMESPACE)),$(strip $(RECIPE_PACK))),)
 endif
 	@NAMESPACE="$(NAMESPACE)" RECIPE_PACK="$(RECIPE_PACK)" BUMP="$(BUMP)" PRERELEASE_LABEL="$(PRERELEASE_LABEL)" ./.github/scripts/release/next-version.sh
 
+.PHONY: release-changes
+release-changes: ## Show whether a namespace or recipe pack has changed since its last release (requires NAMESPACE or RECIPE_PACK)
+ifeq ($(strip $(NAMESPACE))$(strip $(RECIPE_PACK)),)
+	$(error NAMESPACE or RECIPE_PACK parameter is required. Usage: make release-changes NAMESPACE=Radius.Data | make release-changes RECIPE_PACK=kubernetes)
+endif
+ifneq ($(and $(strip $(NAMESPACE)),$(strip $(RECIPE_PACK))),)
+	$(error NAMESPACE and RECIPE_PACK are mutually exclusive. Set exactly one of them)
+endif
+	@NAMESPACE="$(NAMESPACE)" RECIPE_PACK="$(RECIPE_PACK)" ./.github/scripts/release/detect-changes.sh
+
 .PHONY: release-bundle
 release-bundle: ## Build a namespace manifest or recipe pack bundle locally (requires NAMESPACE or RECIPE_PACK, and VERSION; optional OUT_DIR)
 ifeq ($(strip $(NAMESPACE))$(strip $(RECIPE_PACK)),)

--- a/.github/scripts/release/detect-changes.sh
+++ b/.github/scripts/release/detect-changes.sh
@@ -54,7 +54,10 @@
 #   previous_tag  the release tag compared against, or "none"
 #   reason        no-previous-release | previous-release-unreachable |
 #                 changes-detected | no-changes
-#   count         number of changed files in the release scope
+#   count         number of files in the release scope this run would publish:
+#                 the diff against the baseline, or -- when there is no usable
+#                 baseline to diff against -- every file in the scope. Read it
+#                 together with `reason`.
 #
 # Usage:
 #   NAMESPACE=Radius.Data ./.github/scripts/release/detect-changes.sh
@@ -90,8 +93,7 @@ esac
 
 PREVIOUS_TAG="$(rtc_latest_tag "$RTC_UNIT_TAG_PREFIX")"
 CHANGED="true"
-COUNT=0
-CHANGED_FILES=""
+REASON=""
 
 if [[ -z "$PREVIOUS_TAG" ]]; then
     REASON="no-previous-release"
@@ -100,11 +102,27 @@ elif ! git -C "$RTC_REPO_ROOT" rev-parse -q --verify "${PREVIOUS_TAG}^{commit}" 
     # unfetched tag) is not evidence that nothing changed, and skipping a real
     # release is worse than cutting a redundant one.
     REASON="previous-release-unreachable"
+fi
+
+if [[ -n "$REASON" ]]; then
+    # No usable baseline, so compare against the empty tree: every file the unit
+    # ships reads as added. That keeps a single diff path -- identical pathspec
+    # semantics -- and reports the release scope instead of a bare "0 files",
+    # which would contradict the `changed=true` these cases fail open with.
+    BASELINE="$(git -C "$RTC_REPO_ROOT" hash-object -t tree /dev/null)"
 else
-    CHANGED_FILES="$(git -C "$RTC_REPO_ROOT" diff --name-only \
-        "$PREVIOUS_TAG" "$REF" -- "${PATHSPECS[@]}")"
-    if [[ -n "$CHANGED_FILES" ]]; then
-        COUNT="$(grep -c '' <<<"$CHANGED_FILES")"
+    BASELINE="$PREVIOUS_TAG"
+fi
+
+CHANGED_FILES="$(git -C "$RTC_REPO_ROOT" diff --name-only \
+    "$BASELINE" "$REF" -- "${PATHSPECS[@]}")"
+COUNT=0
+if [[ -n "$CHANGED_FILES" ]]; then
+    COUNT="$(grep -c '' <<<"$CHANGED_FILES")"
+fi
+
+if [[ -z "$REASON" ]]; then
+    if [[ "$COUNT" -gt 0 ]]; then
         REASON="changes-detected"
     else
         CHANGED="false"

--- a/.github/scripts/release/detect-changes.sh
+++ b/.github/scripts/release/detect-changes.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+# ------------------------------------------------------------
+# Copyright 2025 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# =============================================================================
+# detect-changes.sh
+# -----------------------------------------------------------------------------
+# Answer one question for a single released unit: is there anything new to
+# release? This repository is a monorepo whose namespaces and recipe packs are
+# versioned independently, so the answer is scoped to the files that unit
+# actually ships -- churn anywhere else in the repository must not push a
+# namespace or a recipe pack to a new version.
+#
+# The comparison is against the commit the unit's latest STABLE release tag
+# points at, so it is a content comparison rather than a commit count: a change
+# that was reverted before the release leaves nothing to publish and is
+# reported as unchanged. Prereleases are deliberately not used as the baseline
+# -- they are staging artifacts, and promoting one to a stable release must
+# never be blocked for lack of further changes.
+#
+# Release scope:
+#   * namespace    the whole category directory, minus the per-type `test/`
+#                  applications. Manifests and READMEs go into the release
+#                  bundle, and the recipes beside them are published to GHCR
+#                  under the release commit's SHA -- the tag Radius resolves
+#                  this namespace pin to (radius PR #12566) -- so a recipe-only
+#                  change is a releasable change. Test applications never ship.
+#   * recipe pack  the pack directory (its Bicep templates and README).
+#
+# Inputs (environment variables):
+#   NAMESPACE     a namespace to release, e.g. Radius.Data
+#   RECIPE_PACK   a recipe pack to release, e.g. kubernetes
+#                 (exactly one of NAMESPACE or RECIPE_PACK is required)
+#   REF           the commit to release (default: HEAD)
+#   REPO_ROOT     repository root (default: git toplevel, else CWD)
+#   GITHUB_OUTPUT optional; when set, outputs are written there too
+#
+# Outputs (stdout summary + $GITHUB_OUTPUT):
+#   changed       "true" | "false"
+#   previous_tag  the release tag compared against, or "none"
+#   reason        no-previous-release | previous-release-unreachable |
+#                 changes-detected | no-changes
+#   count         number of changed files in the release scope
+#
+# Usage:
+#   NAMESPACE=Radius.Data ./.github/scripts/release/detect-changes.sh
+#   RECIPE_PACK=kubernetes ./.github/scripts/release/detect-changes.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.github/scripts/release/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REF="${REF:-HEAD}"
+
+rtc_resolve_unit
+
+# The git pathspecs covering this unit's release scope.
+case "$RTC_UNIT_KIND" in
+    namespace)
+        FOLDER="$(rtc_folder_for_namespace "$RTC_UNIT")"
+        PATHSPECS=("$FOLDER" ":(exclude,glob)${FOLDER}/*/test/**")
+        ;;
+    recipe-pack)
+        PATHSPECS=("$(rtc_recipe_pack_dir "$RTC_UNIT")")
+        ;;
+    *)
+        # An empty pathspec would compare the whole repository, which is exactly
+        # what this script exists to avoid.
+        echo "Error: unknown unit kind '$RTC_UNIT_KIND'" >&2
+        exit 1
+        ;;
+esac
+
+PREVIOUS_TAG="$(rtc_latest_tag "$RTC_UNIT_TAG_PREFIX")"
+CHANGED="true"
+COUNT=0
+CHANGED_FILES=""
+
+if [[ -z "$PREVIOUS_TAG" ]]; then
+    REASON="no-previous-release"
+elif ! git -C "$RTC_REPO_ROOT" rev-parse -q --verify "${PREVIOUS_TAG}^{commit}" >/dev/null 2>&1; then
+    # Fail open. A baseline this checkout cannot see (shallow clone, deleted or
+    # unfetched tag) is not evidence that nothing changed, and skipping a real
+    # release is worse than cutting a redundant one.
+    REASON="previous-release-unreachable"
+else
+    CHANGED_FILES="$(git -C "$RTC_REPO_ROOT" diff --name-only \
+        "$PREVIOUS_TAG" "$REF" -- "${PATHSPECS[@]}")"
+    if [[ -n "$CHANGED_FILES" ]]; then
+        COUNT="$(grep -c '' <<<"$CHANGED_FILES")"
+        REASON="changes-detected"
+    else
+        CHANGED="false"
+        REASON="no-changes"
+    fi
+fi
+
+rtc_emit "changed" "$CHANGED"
+rtc_emit "previous_tag" "${PREVIOUS_TAG:-none}"
+rtc_emit "reason" "$REASON"
+rtc_emit "count" "$COUNT"
+
+{
+    printf '%-14s %s\n' "$RTC_UNIT_LABEL" "$RTC_UNIT"
+    printf '%-14s %s\n' "Baseline:" "${PREVIOUS_TAG:-none}"
+    printf '%-14s %s\n' "Ref:" "$REF"
+    printf '%-14s %s\n' "Changed:" "$CHANGED"
+    printf '%-14s %s\n' "Reason:" "$REASON"
+    printf '%-14s %s\n' "Files:" "$COUNT"
+    if [[ -n "$CHANGED_FILES" ]]; then
+        head -n 20 <<<"$CHANGED_FILES" | sed 's/^/  - /'
+        if [[ "$COUNT" -gt 20 ]]; then
+            echo "  - ... and $((COUNT - 20)) more"
+        fi
+    fi
+} >&2

--- a/.github/scripts/release/lib.sh
+++ b/.github/scripts/release/lib.sh
@@ -50,6 +50,52 @@ RTC_RELEASE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=.github/scripts/lib-namespaces.sh
 source "$RTC_RELEASE_LIB_DIR/../lib-namespaces.sh"
 
+# Resolve the unit to release from the NAMESPACE / RECIPE_PACK environment
+# variables (exactly one must be set) and validate it. Every release script
+# takes the same pair, so this is where that contract lives. On success sets:
+#   RTC_UNIT_KIND        namespace | recipe-pack
+#   RTC_UNIT             the unit name (e.g. Radius.Data, kubernetes)
+#   RTC_UNIT_LABEL       label for human-readable summaries
+#   RTC_UNIT_TAG_PREFIX  tag prefix; tags are `<prefix>/v<version>`
+# shellcheck disable=SC2034 # RTC_UNIT_* are read by the calling scripts
+rtc_resolve_unit() {
+    local namespace="${NAMESPACE:-}" recipe_pack="${RECIPE_PACK:-}"
+
+    if [[ -n "$namespace" && -n "$recipe_pack" ]]; then
+        echo "Error: set either NAMESPACE or RECIPE_PACK, not both" >&2
+        return 1
+    fi
+
+    if [[ -n "$recipe_pack" ]]; then
+        if ! rtc_is_recipe_pack "$recipe_pack"; then
+            echo "Error: '$recipe_pack' is not a releasable recipe pack. Known recipe packs:" >&2
+            rtc_list_recipe_packs | sed 's/^/  - /' >&2
+            return 1
+        fi
+        RTC_UNIT_KIND="recipe-pack"
+        RTC_UNIT="$recipe_pack"
+        RTC_UNIT_LABEL="Recipe pack:"
+        RTC_UNIT_TAG_PREFIX="$(rtc_recipe_pack_tag_prefix "$recipe_pack")"
+        return 0
+    fi
+
+    if [[ -n "$namespace" ]]; then
+        if ! rtc_is_namespace "$namespace"; then
+            echo "Error: '$namespace' is not a releasable namespace. Known namespaces:" >&2
+            rtc_list_namespaces | sed 's/^/  - /' >&2
+            return 1
+        fi
+        RTC_UNIT_KIND="namespace"
+        RTC_UNIT="$namespace"
+        RTC_UNIT_LABEL="Namespace:"
+        RTC_UNIT_TAG_PREFIX="$namespace"
+        return 0
+    fi
+
+    echo "Error: NAMESPACE or RECIPE_PACK is required (e.g. NAMESPACE=Radius.Data or RECIPE_PACK=kubernetes)" >&2
+    return 1
+}
+
 # Print the highest existing STABLE version (X.Y.Z, no prerelease suffix) for a
 # tag series, derived from git tags. `prefix` identifies the released unit (e.g.
 # `Radius.Data` or `recipe-pack/kubernetes`) and tags are `<prefix>/v<version>`.
@@ -64,6 +110,16 @@ rtc_latest_version() {
             fi
         done |
         sort -V | tail -n1
+}
+
+# Print the tag of the latest stable release for a series, or nothing when the
+# unit has never been released. This is the baseline both the change detection
+# and the release notes compare against, so they always tell the same story.
+rtc_latest_tag() {
+    local prefix="$1" version
+    version="$(rtc_latest_version "$prefix")"
+    [[ -n "$version" ]] || return 0
+    echo "${prefix}/v${version}"
 }
 
 # Bump a base X.Y.Z version by patch|minor|major. Any prerelease suffix on the

--- a/.github/scripts/release/next-version.sh
+++ b/.github/scripts/release/next-version.sh
@@ -56,36 +56,10 @@ RECIPE_PACK="${RECIPE_PACK:-}"
 BUMP="${BUMP:-minor}"
 PRERELEASE_LABEL="${PRERELEASE_LABEL:-}"
 
-if [[ -n "$NAMESPACE" && -n "$RECIPE_PACK" ]]; then
-    echo "Error: set either NAMESPACE or RECIPE_PACK, not both" >&2
-    exit 1
-fi
-
 # Resolve the released unit into its tag prefix; tags are `<prefix>/v<version>`.
-if [[ -n "$RECIPE_PACK" ]]; then
-    if ! rtc_is_recipe_pack "$RECIPE_PACK"; then
-        echo "Error: '$RECIPE_PACK' is not a releasable recipe pack. Known recipe packs:" >&2
-        rtc_list_recipe_packs | sed 's/^/  - /' >&2
-        exit 1
-    fi
-    UNIT_LABEL="Recipe pack:"
-    UNIT="$RECIPE_PACK"
-    PREFIX="$(rtc_recipe_pack_tag_prefix "$RECIPE_PACK")"
-elif [[ -n "$NAMESPACE" ]]; then
-    if ! rtc_is_namespace "$NAMESPACE"; then
-        echo "Error: '$NAMESPACE' is not a releasable namespace. Known namespaces:" >&2
-        rtc_list_namespaces | sed 's/^/  - /' >&2
-        exit 1
-    fi
-    UNIT_LABEL="Namespace:"
-    UNIT="$NAMESPACE"
-    PREFIX="$NAMESPACE"
-else
-    echo "Error: NAMESPACE or RECIPE_PACK is required (e.g. NAMESPACE=Radius.Data or RECIPE_PACK=kubernetes)" >&2
-    exit 1
-fi
+rtc_resolve_unit
 
-CURRENT="$(rtc_latest_version "$PREFIX")"
+CURRENT="$(rtc_latest_version "$RTC_UNIT_TAG_PREFIX")"
 BASE="${CURRENT:-0.0.0}"
 NEXT="$(rtc_semver_bump "$BASE" "$BUMP")"
 
@@ -101,7 +75,7 @@ if [[ -n "$PRERELEASE_LABEL" ]]; then
     IS_PRERELEASE="true"
 fi
 
-TAG="${PREFIX}/v${NEXT}"
+TAG="${RTC_UNIT_TAG_PREFIX}/v${NEXT}"
 
 if git -C "$RTC_REPO_ROOT" rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; then
     echo "Error: tag '${TAG}' already exists" >&2
@@ -114,7 +88,7 @@ rtc_emit "tag" "$TAG"
 rtc_emit "is_prerelease" "$IS_PRERELEASE"
 
 {
-    printf '%-14s %s\n' "$UNIT_LABEL" "$UNIT"
+    printf '%-14s %s\n' "$RTC_UNIT_LABEL" "$RTC_UNIT"
     printf '%-14s %s\n' "Current:" "${CURRENT:-none}"
     printf '%-14s %s\n' "Bump:" "$BUMP"
     printf '%-14s %s\n' "Next:" "$NEXT"

--- a/.github/scripts/tests/test-release-automation.sh
+++ b/.github/scripts/tests/test-release-automation.sh
@@ -260,6 +260,9 @@ test_release_change_detection() {
     assert_eq "true" "$(output_value "$output" changed)" "unreleased namespace changed"
     assert_eq "no-previous-release" "$(output_value "$output" reason)" "unreleased namespace reason"
     assert_eq "none" "$(output_value "$output" previous_tag)" "unreleased namespace baseline"
+    # A first release publishes the whole scope, so reporting "0 files" would
+    # contradict the `changed=true` it just emitted.
+    assert_eq "1" "$(output_value "$output" count)" "unreleased namespace file count"
 
     git -C "$repo" tag "Radius.Data/v0.1.0"
     git -C "$repo" tag "recipe-pack/kubernetes/v0.1.0"
@@ -308,6 +311,19 @@ test_release_change_detection() {
     detect_changes "$repo" "$output" NAMESPACE Radius.Data
     assert_eq "Radius.Data/v0.1.0" "$(output_value "$output" previous_tag)" "prerelease used as baseline"
     assert_eq "true" "$(output_value "$output" changed)" "prerelease promotion changed"
+
+    # A baseline this checkout cannot resolve fails open, and the count still
+    # describes the release scope instead of claiming nothing changed. The tag
+    # points at a blob, which stands in for any baseline that will not peel to a
+    # commit (shallow clone, deleted or unfetched tag).
+    local broken="$TEST_ROOT/changes-unreachable" broken_output="$TEST_ROOT/changes-unreachable.out" blob
+    create_repo "$broken" "Data"
+    blob="$(git -C "$broken" hash-object -w --stdin <<<"not a commit")"
+    git -C "$broken" update-ref "refs/tags/Radius.Data/v0.1.0" "$blob"
+    detect_changes "$broken" "$broken_output" NAMESPACE Radius.Data
+    assert_eq "true" "$(output_value "$broken_output" changed)" "unreachable baseline changed"
+    assert_eq "previous-release-unreachable" "$(output_value "$broken_output" reason)" "unreachable baseline reason"
+    assert_eq "1" "$(output_value "$broken_output" count)" "unreachable baseline file count"
 }
 
 test_recipe_tags() {

--- a/.github/scripts/tests/test-release-automation.sh
+++ b/.github/scripts/tests/test-release-automation.sh
@@ -21,6 +21,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SYNC_SCRIPT="${REPO_ROOT}/.github/scripts/compute-radius-sync-payload.sh"
 VERSION_SCRIPT="${REPO_ROOT}/.github/scripts/release/next-version.sh"
+CHANGES_SCRIPT="${REPO_ROOT}/.github/scripts/release/detect-changes.sh"
 BUNDLE_SCRIPT="${REPO_ROOT}/.github/scripts/release/build-recipe-pack-bundle.sh"
 TAGS_SCRIPT="${REPO_ROOT}/.github/scripts/resolve-recipe-tags.sh"
 TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rtc-release-tests-XXXXXX")"
@@ -41,11 +42,20 @@ output_value() {
     sed -n "s/^${key}=//p" "$file" | tail -n1
 }
 
-create_repo() {
-    local repo="$1" category="$2"
+# Local repo config beats the developer's global config, so fixtures still
+# commit and tag on machines that enforce signing.
+init_repo() {
+    local repo="$1"
     git init -q "$repo"
     git -C "$repo" config user.name "Release Test"
     git -C "$repo" config user.email "release-test@example.com"
+    git -C "$repo" config commit.gpgsign false
+    git -C "$repo" config tag.gpgSign false
+}
+
+create_repo() {
+    local repo="$1" category="$2"
+    init_repo "$repo"
     mkdir -p "$repo/$category/widgets"
     cat >"$repo/$category/widgets/widget.yaml" <<EOF
 namespace: Radius.${category}
@@ -61,9 +71,7 @@ EOF
 
 create_recipe_pack_repo() {
     local repo="$1" pack="$2"
-    git init -q "$repo"
-    git -C "$repo" config user.name "Release Test"
-    git -C "$repo" config user.email "release-test@example.com"
+    init_repo "$repo"
     mkdir -p "$repo/recipe-packs/$pack"
     cat >"$repo/recipe-packs/$pack/default-recipepack.bicep" <<'EOF'
 extension radius
@@ -71,6 +79,23 @@ EOF
     echo "# ${pack} recipe pack" >"$repo/recipe-packs/$pack/README.md"
     git -C "$repo" add .
     git -C "$repo" commit -q -m "add ${pack} recipe pack"
+}
+
+commit_file() {
+    local repo="$1" path="$2" content="$3" message="$4"
+    mkdir -p "$repo/$(dirname "$path")"
+    printf '%s\n' "$content" >"$repo/$path"
+    git -C "$repo" add -A
+    git -C "$repo" commit -q -m "$message"
+}
+
+# Run detect-changes.sh for one released unit, writing its outputs to $output.
+detect_changes() {
+    local repo="$1" output="$2" unit_var="$3" unit="$4"
+    : >"$output"
+    env REPO_ROOT="$repo" GITHUB_OUTPUT="$output" "${unit_var}=${unit}" \
+        bash "$CHANGES_SCRIPT" >/dev/null 2>&1 ||
+        fail "change detection failed for ${unit}"
 }
 
 test_deleted_namespace() {
@@ -224,6 +249,67 @@ test_repo_wide_release_covers_all_units() {
     assert_eq "Radius.Data" "$(jq -r '.namespaces[0].namespace' <<<"$payload")" "repo-wide namespace alias"
 }
 
+test_release_change_detection() {
+    local repo="$TEST_ROOT/changes" output="$TEST_ROOT/changes.out"
+    create_repo "$repo" "Data"
+    commit_file "$repo" "recipe-packs/kubernetes/default-recipepack.bicep" \
+        "extension radius" "add kubernetes recipe pack"
+
+    # Never released: there is always something to publish.
+    detect_changes "$repo" "$output" NAMESPACE Radius.Data
+    assert_eq "true" "$(output_value "$output" changed)" "unreleased namespace changed"
+    assert_eq "no-previous-release" "$(output_value "$output" reason)" "unreleased namespace reason"
+    assert_eq "none" "$(output_value "$output" previous_tag)" "unreleased namespace baseline"
+
+    git -C "$repo" tag "Radius.Data/v0.1.0"
+    git -C "$repo" tag "recipe-pack/kubernetes/v0.1.0"
+
+    # Released at this very commit: nothing new to publish.
+    detect_changes "$repo" "$output" NAMESPACE Radius.Data
+    assert_eq "false" "$(output_value "$output" changed)" "released namespace changed"
+    assert_eq "no-changes" "$(output_value "$output" reason)" "released namespace reason"
+    assert_eq "Radius.Data/v0.1.0" "$(output_value "$output" previous_tag)" "released namespace baseline"
+
+    # Test applications never ship, so they are not a reason to release.
+    commit_file "$repo" "Data/widgets/test/app.bicep" "extension radius" "add widget test app"
+    detect_changes "$repo" "$output" NAMESPACE Radius.Data
+    assert_eq "false" "$(output_value "$output" changed)" "test-only change changed"
+
+    # A recipe does ship: it is published under the release commit's SHA.
+    commit_file "$repo" "Data/widgets/recipes/kubernetes/bicep/widget.bicep" \
+        "param context object" "add widget recipe"
+    detect_changes "$repo" "$output" NAMESPACE Radius.Data
+    assert_eq "true" "$(output_value "$output" changed)" "recipe change changed"
+    assert_eq "1" "$(output_value "$output" count)" "recipe change file count"
+
+    # Independent lifecycles: namespace churn must not release the recipe pack.
+    detect_changes "$repo" "$output" RECIPE_PACK kubernetes
+    assert_eq "false" "$(output_value "$output" changed)" "unrelated namespace change changed the pack"
+
+    commit_file "$repo" "recipe-packs/kubernetes/default-recipepack.bicep" \
+        "extension radius // updated" "update kubernetes recipe pack"
+    detect_changes "$repo" "$output" RECIPE_PACK kubernetes
+    assert_eq "true" "$(output_value "$output" changed)" "recipe pack change changed"
+
+    # A reverted change leaves nothing to publish, even though commits exist.
+    local pack_repo="$TEST_ROOT/changes-revert" pack_output="$TEST_ROOT/changes-revert.out"
+    create_recipe_pack_repo "$pack_repo" "azure"
+    git -C "$pack_repo" tag "recipe-pack/azure/v0.1.0"
+    commit_file "$pack_repo" "recipe-packs/azure/default-recipepack.bicep" \
+        "extension radius // temporary" "tweak azure recipe pack"
+    commit_file "$pack_repo" "recipe-packs/azure/default-recipepack.bicep" \
+        "extension radius" "revert azure recipe pack tweak"
+    detect_changes "$pack_repo" "$pack_output" RECIPE_PACK azure
+    assert_eq "false" "$(output_value "$pack_output" changed)" "reverted change changed"
+
+    # Prereleases are staging artifacts, so they are never the baseline --
+    # promoting one to a stable release must not be blocked.
+    git -C "$repo" tag "Radius.Data/v0.2.0-rc.1"
+    detect_changes "$repo" "$output" NAMESPACE Radius.Data
+    assert_eq "Radius.Data/v0.1.0" "$(output_value "$output" previous_tag)" "prerelease used as baseline"
+    assert_eq "true" "$(output_value "$output" changed)" "prerelease promotion changed"
+}
+
 test_recipe_tags() {
     local sha="0123456789abcdef0123456789abcdef01234567"
 
@@ -255,5 +341,6 @@ test_recipe_pack_bundle
 test_recipe_pack_release_is_synced
 test_recipe_pack_push_is_synced
 test_repo_wide_release_covers_all_units
+test_release_change_detection
 test_recipe_tags
 echo "Release automation tests passed"

--- a/.github/workflows/release-namespace.yaml
+++ b/.github/workflows/release-namespace.yaml
@@ -25,7 +25,8 @@ name: Release Namespace
 # against the namespace's own latest stable release tag and looks only at the
 # files that namespace ships -- unrelated churn elsewhere in the monorepo never
 # bumps its version. When nothing changed, no tag, release, or recipe publish is
-# created; `force` overrides that for a deliberate re-cut.
+# created; `force` overrides that for a deliberate re-cut. A `dry_run` publishes
+# nothing, so it previews the version and the bundle either way.
 #
 # Downstream: publishing the release fires `notify-radius.yaml` on
 # `release: published`, which dispatches the per-namespace pin (this tag) to
@@ -120,19 +121,40 @@ jobs:
         env:
           NAMESPACE: ${{ inputs.namespace }}
           CHANGED: ${{ steps.changes.outputs.changed }}
+          REASON: ${{ steps.changes.outputs.reason }}
           PREVIOUS_TAG: ${{ steps.changes.outputs.previous_tag }}
           COUNT: ${{ steps.changes.outputs.count }}
           FORCED: ${{ inputs.force }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
+          # With no baseline to diff against, the count is the whole release
+          # scope rather than a change count -- say so instead of reporting it
+          # as if a comparison had happened.
+          case "$REASON" in
+            no-previous-release)
+              scope="Files in the release scope: \`${COUNT}\` (first release, so every file is new)"
+              verdict="first release -- continuing"
+              ;;
+            previous-release-unreachable)
+              scope="Files in the release scope: \`${COUNT}\` (nothing was compared: the baseline is unreachable from this checkout)"
+              verdict="cannot compare against \`${PREVIOUS_TAG}\` -- continuing rather than skip a real release"
+              ;;
+            *)
+              scope="Changed files in the release scope: \`${COUNT}\`"
+              verdict="changes found -- continuing with the release"
+              ;;
+          esac
           {
             echo "## Unreleased changes in ${NAMESPACE}"
             echo ""
             echo "* Baseline: \`${PREVIOUS_TAG}\`"
-            echo "* Changed files in the release scope: \`${COUNT}\`"
+            echo "* ${scope}"
             if [ "$CHANGED" = "true" ]; then
-              echo "* Result: changes found -- continuing with the release"
+              echo "* Result: ${verdict}"
             elif [ "$FORCED" = "true" ]; then
               echo "* Result: unchanged, but \`force\` was set -- continuing with the release"
+            elif [ "$DRY_RUN" = "true" ]; then
+              echo "* Result: unchanged, but a dry run publishes nothing -- continuing with the preview"
             else
               echo "* Result: **nothing to release**"
               echo ""
@@ -162,13 +184,20 @@ jobs:
   release:
     name: Release ${{ inputs.namespace }}
     needs: [check, publish-recipes]
+    # A dry run publishes nothing, so the change gate does not apply to it --
+    # previewing the version and the bundle must never require `force`. Only a
+    # real release is gated on there being something to release.
     if: >-
       !cancelled() &&
       github.repository == 'radius-project/resource-types-contrib' &&
-      needs.check.outputs.should_release == 'true' &&
       (
         (inputs.dry_run && needs.publish-recipes.result == 'skipped') ||
-        (!inputs.dry_run && github.ref == 'refs/heads/main' && needs.publish-recipes.result == 'success')
+        (
+          !inputs.dry_run &&
+          github.ref == 'refs/heads/main' &&
+          needs.check.outputs.should_release == 'true' &&
+          needs.publish-recipes.result == 'success'
+        )
       )
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -307,7 +336,7 @@ jobs:
       - name: Summarize
         env:
           DRY_RUN: ${{ inputs.dry_run }}
-          FORCED: ${{ needs.check.outputs.changed != 'true' }}
+          UNCHANGED: ${{ needs.check.outputs.changed != 'true' }}
         run: |
           {
             echo "## Release ${{ steps.ver.outputs.tag }}"
@@ -315,8 +344,8 @@ jobs:
             echo "* Namespace: \`${{ inputs.namespace }}\`"
             echo "* Current -> next: \`${{ steps.ver.outputs.current }}\` -> \`${{ steps.ver.outputs.next }}\`"
             echo "* Since previous tag: \`${{ steps.notes.outputs.prev }}\`"
-            if [ "$FORCED" = "true" ]; then
-              echo "* Forced: no changes since the previous release"
+            if [ "$UNCHANGED" = "true" ]; then
+              echo "* Nothing changed since the previous release"
             fi
             echo "* Prerelease: \`${{ steps.ver.outputs.is_prerelease }}\`"
             echo "* Manifests bundled: \`${{ steps.bundle.outputs.count }}\`"

--- a/.github/workflows/release-namespace.yaml
+++ b/.github/workflows/release-namespace.yaml
@@ -20,6 +20,13 @@ name: Release Namespace
 # versioned artifacts is what makes Radius's per-namespace `resourceTypes[].ref`
 # pins meaningful.
 #
+# The run is a no-op unless the namespace has something new to publish. Each
+# namespace is released on its own cadence, so the check compares this commit
+# against the namespace's own latest stable release tag and looks only at the
+# files that namespace ships -- unrelated churn elsewhere in the monorepo never
+# bumps its version. When nothing changed, no tag, release, or recipe publish is
+# created; `force` overrides that for a deliberate re-cut.
+#
 # Downstream: publishing the release fires `notify-radius.yaml` on
 # `release: published`, which dispatches the per-namespace pin (this tag) to
 # radius-project/radius as a reviewable sync PR. The release is created with the
@@ -64,6 +71,11 @@ on:
         type: string
         required: false
         default: ""
+      force:
+        description: Release even when nothing changed since the last release
+        type: boolean
+        required: false
+        default: false
       dry_run:
         description: Compute the version and build the bundle without tagging or publishing
         type: boolean
@@ -78,6 +90,56 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check:
+    name: Check ${{ inputs.namespace }} for unreleased changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      # The gate for every other job: a release is only worth cutting when this
+      # namespace changed since its own last stable release.
+      should_release: ${{ steps.changes.outputs.changed == 'true' || inputs.force }}
+      changed: ${{ steps.changes.outputs.changed }}
+      previous_tag: ${{ steps.changes.outputs.previous_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags so the baseline release tag resolves.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect changes since the last release
+        id: changes
+        env:
+          NAMESPACE: ${{ inputs.namespace }}
+        run: ./.github/scripts/release/detect-changes.sh
+
+      - name: Summarize
+        env:
+          NAMESPACE: ${{ inputs.namespace }}
+          CHANGED: ${{ steps.changes.outputs.changed }}
+          PREVIOUS_TAG: ${{ steps.changes.outputs.previous_tag }}
+          COUNT: ${{ steps.changes.outputs.count }}
+          FORCED: ${{ inputs.force }}
+        run: |
+          {
+            echo "## Unreleased changes in ${NAMESPACE}"
+            echo ""
+            echo "* Baseline: \`${PREVIOUS_TAG}\`"
+            echo "* Changed files in the release scope: \`${COUNT}\`"
+            if [ "$CHANGED" = "true" ]; then
+              echo "* Result: changes found -- continuing with the release"
+            elif [ "$FORCED" = "true" ]; then
+              echo "* Result: unchanged, but \`force\` was set -- continuing with the release"
+            else
+              echo "* Result: **nothing to release**"
+              echo ""
+              echo "\`${NAMESPACE}\` is unchanged since \`${PREVIOUS_TAG}\`, so no tag, release, or recipe publish was created. Re-run with \`force\` to cut a release anyway."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   publish-recipes:
     name: Publish recipes for the release commit
     # A namespace pin is also an OCI coordinate: a released `rad` resolves
@@ -88,7 +150,8 @@ jobs:
     # and Radius never sees a pin it cannot resolve. `pin_only` keeps the
     # floating `edge`/`latest` aliases where they are; only the immutable SHA
     # tag is (re)published.
-    if: ${{ !inputs.dry_run }}
+    needs: check
+    if: ${{ !inputs.dry_run && needs.check.outputs.should_release == 'true' }}
     permissions:
       contents: read
       packages: write
@@ -98,10 +161,11 @@ jobs:
 
   release:
     name: Release ${{ inputs.namespace }}
-    needs: publish-recipes
+    needs: [check, publish-recipes]
     if: >-
       !cancelled() &&
       github.repository == 'radius-project/resource-types-contrib' &&
+      needs.check.outputs.should_release == 'true' &&
       (
         (inputs.dry_run && needs.publish-recipes.result == 'skipped') ||
         (!inputs.dry_run && github.ref == 'refs/heads/main' && needs.publish-recipes.result == 'success')
@@ -144,11 +208,17 @@ jobs:
         env:
           NAMESPACE: ${{ inputs.namespace }}
           TAG: ${{ steps.ver.outputs.tag }}
+          # Same baseline the change check used, so the notes and the decision
+          # to release describe the same range.
+          PREV: ${{ needs.check.outputs.previous_tag }}
         run: |
           set -euo pipefail
           mkdir -p dist
           folder="${NAMESPACE#Radius.}"
-          prev="$(git tag --list "${NAMESPACE}/v*" --sort=-v:refname | head -n1 || true)"
+          prev="$PREV"
+          if [ "$prev" = "none" ]; then
+            prev=""
+          fi
           if [ -n "$prev" ]; then
             range="${prev}..HEAD"
           else
@@ -237,6 +307,7 @@ jobs:
       - name: Summarize
         env:
           DRY_RUN: ${{ inputs.dry_run }}
+          FORCED: ${{ needs.check.outputs.changed != 'true' }}
         run: |
           {
             echo "## Release ${{ steps.ver.outputs.tag }}"
@@ -244,6 +315,9 @@ jobs:
             echo "* Namespace: \`${{ inputs.namespace }}\`"
             echo "* Current -> next: \`${{ steps.ver.outputs.current }}\` -> \`${{ steps.ver.outputs.next }}\`"
             echo "* Since previous tag: \`${{ steps.notes.outputs.prev }}\`"
+            if [ "$FORCED" = "true" ]; then
+              echo "* Forced: no changes since the previous release"
+            fi
             echo "* Prerelease: \`${{ steps.ver.outputs.is_prerelease }}\`"
             echo "* Manifests bundled: \`${{ steps.bundle.outputs.count }}\`"
             echo "* Asset: \`$(basename "${{ steps.bundle.outputs.asset }}")\`"

--- a/.github/workflows/release-recipe-pack.yaml
+++ b/.github/workflows/release-recipe-pack.yaml
@@ -24,7 +24,8 @@ name: Release Recipe Pack
 # pack's own latest stable release tag and looks only at that pack's directory --
 # unrelated churn elsewhere in the monorepo never bumps its version. When nothing
 # changed, no tag or release is created; `force` overrides that for a deliberate
-# re-cut.
+# re-cut. A `dry_run` publishes nothing, so it previews the version and the
+# bundle either way.
 #
 # Downstream: publishing the release fires `notify-radius.yaml` on
 # `release: published`, which dispatches the pack pin (this tag) to
@@ -115,19 +116,40 @@ jobs:
         env:
           RECIPE_PACK: ${{ inputs.recipe_pack }}
           CHANGED: ${{ steps.changes.outputs.changed }}
+          REASON: ${{ steps.changes.outputs.reason }}
           PREVIOUS_TAG: ${{ steps.changes.outputs.previous_tag }}
           COUNT: ${{ steps.changes.outputs.count }}
           FORCED: ${{ inputs.force }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
+          # With no baseline to diff against, the count is the whole release
+          # scope rather than a change count -- say so instead of reporting it
+          # as if a comparison had happened.
+          case "$REASON" in
+            no-previous-release)
+              scope="Files in the release scope: \`${COUNT}\` (first release, so every file is new)"
+              verdict="first release -- continuing"
+              ;;
+            previous-release-unreachable)
+              scope="Files in the release scope: \`${COUNT}\` (nothing was compared: the baseline is unreachable from this checkout)"
+              verdict="cannot compare against \`${PREVIOUS_TAG}\` -- continuing rather than skip a real release"
+              ;;
+            *)
+              scope="Changed files in the release scope: \`${COUNT}\`"
+              verdict="changes found -- continuing with the release"
+              ;;
+          esac
           {
             echo "## Unreleased changes in the ${RECIPE_PACK} recipe pack"
             echo ""
             echo "* Baseline: \`${PREVIOUS_TAG}\`"
-            echo "* Changed files in the release scope: \`${COUNT}\`"
+            echo "* ${scope}"
             if [ "$CHANGED" = "true" ]; then
-              echo "* Result: changes found -- continuing with the release"
+              echo "* Result: ${verdict}"
             elif [ "$FORCED" = "true" ]; then
               echo "* Result: unchanged, but \`force\` was set -- continuing with the release"
+            elif [ "$DRY_RUN" = "true" ]; then
+              echo "* Result: unchanged, but a dry run publishes nothing -- continuing with the preview"
             else
               echo "* Result: **nothing to release**"
               echo ""
@@ -138,10 +160,15 @@ jobs:
   release:
     name: Release recipe pack ${{ inputs.recipe_pack }}
     needs: check
+    # A dry run publishes nothing, so the change gate does not apply to it --
+    # previewing the version and the bundle must never require `force`. Only a
+    # real release is gated on there being something to release.
     if: >-
       github.repository == 'radius-project/resource-types-contrib' &&
-      needs.check.outputs.should_release == 'true' &&
-      (inputs.dry_run || github.ref == 'refs/heads/main')
+      (
+        inputs.dry_run ||
+        (github.ref == 'refs/heads/main' && needs.check.outputs.should_release == 'true')
+      )
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
@@ -260,7 +287,7 @@ jobs:
       - name: Summarize
         env:
           DRY_RUN: ${{ inputs.dry_run }}
-          FORCED: ${{ needs.check.outputs.changed != 'true' }}
+          UNCHANGED: ${{ needs.check.outputs.changed != 'true' }}
         run: |
           {
             echo "## Release ${{ steps.ver.outputs.tag }}"
@@ -268,8 +295,8 @@ jobs:
             echo "* Recipe pack: \`${{ inputs.recipe_pack }}\`"
             echo "* Current -> next: \`${{ steps.ver.outputs.current }}\` -> \`${{ steps.ver.outputs.next }}\`"
             echo "* Since previous tag: \`${{ steps.notes.outputs.prev }}\`"
-            if [ "$FORCED" = "true" ]; then
-              echo "* Forced: no changes since the previous release"
+            if [ "$UNCHANGED" = "true" ]; then
+              echo "* Nothing changed since the previous release"
             fi
             echo "* Prerelease: \`${{ steps.ver.outputs.is_prerelease }}\`"
             echo "* Templates bundled: \`${{ steps.bundle.outputs.count }}\`"

--- a/.github/workflows/release-recipe-pack.yaml
+++ b/.github/workflows/release-recipe-pack.yaml
@@ -19,6 +19,13 @@ name: Release Recipe Pack
 # bundle, and publishes a GitHub Release. This mirrors release-namespace.yaml and
 # shares its release scripts.
 #
+# The run is a no-op unless the pack has something new to publish. Each pack is
+# released on its own cadence, so the check compares this commit against the
+# pack's own latest stable release tag and looks only at that pack's directory --
+# unrelated churn elsewhere in the monorepo never bumps its version. When nothing
+# changed, no tag or release is created; `force` overrides that for a deliberate
+# re-cut.
+#
 # Downstream: publishing the release fires `notify-radius.yaml` on
 # `release: published`, which dispatches the pack pin (this tag) to
 # radius-project/radius as a reviewable sync PR. Radius records it under
@@ -59,6 +66,11 @@ on:
         type: string
         required: false
         default: ""
+      force:
+        description: Release even when nothing changed since the last release
+        type: boolean
+        required: false
+        default: false
       dry_run:
         description: Compute the version and build the bundle without tagging or publishing
         type: boolean
@@ -73,10 +85,62 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  check:
+    name: Check ${{ inputs.recipe_pack }} for unreleased changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      # The gate for the release job: a release is only worth cutting when this
+      # pack changed since its own last stable release.
+      should_release: ${{ steps.changes.outputs.changed == 'true' || inputs.force }}
+      changed: ${{ steps.changes.outputs.changed }}
+      previous_tag: ${{ steps.changes.outputs.previous_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history and tags so the baseline release tag resolves.
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect changes since the last release
+        id: changes
+        env:
+          RECIPE_PACK: ${{ inputs.recipe_pack }}
+        run: ./.github/scripts/release/detect-changes.sh
+
+      - name: Summarize
+        env:
+          RECIPE_PACK: ${{ inputs.recipe_pack }}
+          CHANGED: ${{ steps.changes.outputs.changed }}
+          PREVIOUS_TAG: ${{ steps.changes.outputs.previous_tag }}
+          COUNT: ${{ steps.changes.outputs.count }}
+          FORCED: ${{ inputs.force }}
+        run: |
+          {
+            echo "## Unreleased changes in the ${RECIPE_PACK} recipe pack"
+            echo ""
+            echo "* Baseline: \`${PREVIOUS_TAG}\`"
+            echo "* Changed files in the release scope: \`${COUNT}\`"
+            if [ "$CHANGED" = "true" ]; then
+              echo "* Result: changes found -- continuing with the release"
+            elif [ "$FORCED" = "true" ]; then
+              echo "* Result: unchanged, but \`force\` was set -- continuing with the release"
+            else
+              echo "* Result: **nothing to release**"
+              echo ""
+              echo "The \`${RECIPE_PACK}\` recipe pack is unchanged since \`${PREVIOUS_TAG}\`, so no tag or release was created. Re-run with \`force\` to cut a release anyway."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
   release:
     name: Release recipe pack ${{ inputs.recipe_pack }}
+    needs: check
     if: >-
       github.repository == 'radius-project/resource-types-contrib' &&
+      needs.check.outputs.should_release == 'true' &&
       (inputs.dry_run || github.ref == 'refs/heads/main')
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -116,11 +180,17 @@ jobs:
         env:
           RECIPE_PACK: ${{ inputs.recipe_pack }}
           TAG: ${{ steps.ver.outputs.tag }}
+          # Same baseline the change check used, so the notes and the decision
+          # to release describe the same range.
+          PREV: ${{ needs.check.outputs.previous_tag }}
         run: |
           set -euo pipefail
           mkdir -p dist
           folder="recipe-packs/${RECIPE_PACK}"
-          prev="$(git tag --list "recipe-pack/${RECIPE_PACK}/v*" --sort=-v:refname | head -n1 || true)"
+          prev="$PREV"
+          if [ "$prev" = "none" ]; then
+            prev=""
+          fi
           if [ -n "$prev" ]; then
             range="${prev}..HEAD"
           else
@@ -190,6 +260,7 @@ jobs:
       - name: Summarize
         env:
           DRY_RUN: ${{ inputs.dry_run }}
+          FORCED: ${{ needs.check.outputs.changed != 'true' }}
         run: |
           {
             echo "## Release ${{ steps.ver.outputs.tag }}"
@@ -197,6 +268,9 @@ jobs:
             echo "* Recipe pack: \`${{ inputs.recipe_pack }}\`"
             echo "* Current -> next: \`${{ steps.ver.outputs.current }}\` -> \`${{ steps.ver.outputs.next }}\`"
             echo "* Since previous tag: \`${{ steps.notes.outputs.prev }}\`"
+            if [ "$FORCED" = "true" ]; then
+              echo "* Forced: no changes since the previous release"
+            fi
             echo "* Prerelease: \`${{ steps.ver.outputs.is_prerelease }}\`"
             echo "* Templates bundled: \`${{ steps.bundle.outputs.count }}\`"
             echo "* Asset: \`$(basename "${{ steps.bundle.outputs.asset }}")\`"


### PR DESCRIPTION
This pull request introduces a robust mechanism for detecting changes in release units (namespaces or recipe packs) to ensure that new releases are only created when there are actual changes since the last stable release. It adds a new script for change detection, integrates it into the release workflow and Makefile, and provides comprehensive tests to validate the new logic. The main themes are improved release automation, code reuse, and enhanced test coverage.

**Release automation improvements:**

* Added a new script, `detect-changes.sh`, which determines if a namespace or recipe pack has changed since its last stable release, using content comparison scoped to the files that are actually shipped, and ignoring unrelated changes elsewhere in the repository. The script emits structured outputs for downstream automation.
* Added a new Makefile target, `release-changes`, to invoke the change detection script, with validation to ensure either `NAMESPACE` or `RECIPE_PACK` is set (but not both or neither).
* Updated the namespace release workflow (`release-namespace.yaml`) to document and support the new change detection logic, and added a `force` input to allow overriding the check when desired. [[1]](diffhunk://#diff-628197a53a21537e412b3d7af0730e2b03216e7d716f18d801b3cb7c6ec6a57dR23-R29) [[2]](diffhunk://#diff-628197a53a21537e412b3d7af0730e2b03216e7d716f18d801b3cb7c6ec6a57dR74-R78)

**Code reuse and refactoring:**

* Refactored release scripts to use a new `rtc_resolve_unit` function in `lib.sh` for consistent validation and resolution of release units, reducing duplication and enforcing contract across scripts. [[1]](diffhunk://#diff-57ada4665d7d28beb8c5fda0d578045e1c039287df428e4add55d88deb5ca8d8R53-R98) [[2]](diffhunk://#diff-bb1186d733e651dfa008044a19dd5b0e3af2d9ddb7a40fccf0759a1f6174f20fL59-R62)
* Added a helper function, `rtc_latest_tag`, to retrieve the latest stable release tag for a given unit, ensuring consistent baselines for both change detection and release notes.
* Updated `next-version.sh` to use the new shared logic for resolving units and tag prefixes, improving maintainability and reducing errors. [[1]](diffhunk://#diff-bb1186d733e651dfa008044a19dd5b0e3af2d9ddb7a40fccf0759a1f6174f20fL59-R62) [[2]](diffhunk://#diff-bb1186d733e651dfa008044a19dd5b0e3af2d9ddb7a40fccf0759a1f6174f20fL104-R78) [[3]](diffhunk://#diff-bb1186d733e651dfa008044a19dd5b0e3af2d9ddb7a40fccf0759a1f6174f20fL117-R91)

**Testing and validation:**

* Expanded the release automation test suite to cover the new change detection logic, including cases for unreleased units, released units, test-only changes, recipe changes, reverted changes, prerelease handling, and independence between namespaces and recipe packs. Added helper functions for repo initialization and invoking the change detection script in tests. [[1]](diffhunk://#diff-e3d7def5bb78f0ca3a16d54805b32e796edb34f375a324b2da3d2d2d4ccbc79eR24) [[2]](diffhunk://#diff-e3d7def5bb78f0ca3a16d54805b32e796edb34f375a324b2da3d2d2d4ccbc79eL44-R58) [[3]](diffhunk://#diff-e3d7def5bb78f0ca3a16d54805b32e796edb34f375a324b2da3d2d2d4ccbc79eL64-R74) [[4]](diffhunk://#diff-e3d7def5bb78f0ca3a16d54805b32e796edb34f375a324b2da3d2d2d4ccbc79eR84-R100) [[5]](diffhunk://#diff-e3d7def5bb78f0ca3a16d54805b32e796edb34f375a324b2da3d2d2d4ccbc79eR252-R312) [[6]](diffhunk://#diff-e3d7def5bb78f0ca3a16d54805b32e796edb34f375a324b2da3d2d2d4ccbc79eR344)