### PR TITLE
Derive globally unique Azure resource names in the Azure Recipe Pack

### DIFF
--- a/docs/contributing/contributing-resource-types-recipes.md
+++ b/docs/contributing/contributing-resource-types-recipes.md
@@ -270,6 +270,8 @@ Recipes for a Resource Type are added to the platform Recipe Packs under `recipe
 
 Today Radius supports Bicep and Terraform Recipe drivers, so a Recipe can be a Bicep template or a Terraform configuration. It can also point to well-maintained community modules like the [Azure Verified Modules](https://azure.github.io/Azure-Verified-Modules/) or the [AWS Terraform modules](https://registry.terraform.io/namespaces/terraform-aws-modules). When pointing at a standard module, Radius resolves any `{{context.*}}` expressions in the Recipe's `parameters` against the resource being deployed and maps the module's outputs onto the resource's read-only properties via the `outputs` field, so no Radius-specific wrapping is required.
 
+For Azure resources whose names must be globally unique, `{{context.azure.resourceNameHash}}` returns the first 16 lowercase hexadecimal characters of a SHA-256 hash over the lowercased Azure resource-group ID and Radius resource ID. This gives Recipes a stable suffix that meets the naming restrictions of the Azure services in this Recipe Pack.
+
 - Familiarize yourself with the IaC language of your choice, [Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep) or [Terraform](https://developer.hashicorp.com/terraform)
 - Familiarize yourself with the Radius [Recipe](https://docs.radapp.io/guides/recipes) concept
 - Follow this [how-to guide](https://docs.radapp.io/guides/recipes/howto-author-recipes/) to write your first Recipe
@@ -296,8 +298,8 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         // Standard Azure Verified Module, version pinned with `:<tag>`
         source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
         parameters: {
-          // Derive the resource name from the Radius context
-          name: '{{context.resource.name}}'
+          // Redis Enterprise names are global, so use a stable hash-based name
+          name: 'redis-{{context.azure.resourceNameHash}}'
           // Map the developer-authored `size` enum onto a concrete SKU
           skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
           database: {

--- a/docs/contributing/contributing-resource-types-recipes.md
+++ b/docs/contributing/contributing-resource-types-recipes.md
@@ -299,7 +299,8 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
         parameters: {
           // Redis Enterprise names are global, so use a stable hash-based name
-          name: 'redis-{{context.azure.resourceNameHash}}'
+          // prefixed with the Cloud Adoption Framework abbreviation (amr = Azure Managed Redis)
+          name: 'amr-{{context.azure.resourceNameHash}}'
           // Map the developer-authored `size` enum onto a concrete SKU
           skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
           database: {

--- a/recipe-packs/azure/README.md
+++ b/recipe-packs/azure/README.md
@@ -8,6 +8,12 @@ This folder contains the **Azure Recipe Pack** — a collection of Recipes that 
 
 Each pack declares a `Radius.Core/recipePacks` resource whose `recipes` map contains an entry for every Resource Type, and a `Radius.Core/environments` resource that references the pack and configures the Azure provider.
 
+## Azure resource naming
+
+Some Azure services require names that are unique across Azure, so their Recipes combine a short service prefix with `{{context.azure.resourceNameHash}}`. The expression returns the first 16 lowercase hexadecimal characters of a SHA-256 hash over the lowercased Azure resource-group ID and Radius resource ID. The same resource in the same resource group keeps its name across deployments, while changing either ID produces a different name.
+
+This Recipe Pack requires a Radius runtime that supports the `context.azure.resourceNameHash` direct-module expression. Earlier revisions used `context.resource.name` directly, and adopting this revision changes those Azure resource names, which may cause existing edge deployments to provision replacement resources.
+
 ## Recipes in this pack
 
 | Resource Type | Kind | Source |

--- a/recipe-packs/azure/aks-recipepack.bicep
+++ b/recipe-packs/azure/aks-recipepack.bicep
@@ -30,13 +30,13 @@ param postgreSqlServerConfigurations array = []
 resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
   name: 'azure-avm'
   properties: {
-    // Azure resources that need globally unique names use a service prefix and a stable hash.
+    // Globally unique Azure names use the Cloud Adoption Framework resource abbreviation as a prefix, plus a stable hash.
     recipes: {
       'Radius.Data/redisCaches': {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
         parameters: {
-          name: 'redis-{{context.azure.resourceNameHash}}'
+          name: 'amr-{{context.azure.resourceNameHash}}'
           skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
           highAvailability: 'Disabled'
           database: {
@@ -61,10 +61,10 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/cognitive-services/account:0.15.0'
         parameters: {
-          name: 'ai-{{context.azure.resourceNameHash}}'
+          name: 'oai-{{context.azure.resourceNameHash}}'
           kind: 'OpenAI'
           sku: 'S0'
-          customSubDomainName: 'ai-{{context.azure.resourceNameHash}}'
+          customSubDomainName: 'oai-{{context.azure.resourceNameHash}}'
           disableLocalAuth: false
           publicNetworkAccess: 'Enabled'
           deployments: [
@@ -97,7 +97,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/search/search-service:0.12.2'
         parameters: {
-          name: 'search-{{context.azure.resourceNameHash}}'
+          name: 'srch-{{context.azure.resourceNameHash}}'
           sku: 'basic'
           disableLocalAuth: false
           replicaCount: 1
@@ -118,7 +118,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/document-db/database-account:0.19.0'
         parameters: {
-          name: 'cosmos-{{context.azure.resourceNameHash}}'
+          name: 'cosmon-{{context.azure.resourceNameHash}}'
           capabilitiesToAdd: [
             'EnableMongo'
           ]
@@ -183,7 +183,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/db-for-postgre-sql/flexible-server:0.15.2'
         parameters: {
-          name: 'postgres-{{context.azure.resourceNameHash}}'
+          name: 'pgsql-{{context.azure.resourceNameHash}}'
           administratorLogin: '{{context.resource.properties.username}}'
           administratorLoginPassword: '{{context.resource.properties.password}}'
           authConfig: {
@@ -261,7 +261,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/service-bus/namespace:0.16.2'
         parameters: {
-          name: 'sb-{{context.azure.resourceNameHash}}'
+          name: 'sbns-{{context.azure.resourceNameHash}}'
           skuObject: {
             name: 'Standard'
           }
@@ -288,7 +288,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/event-hub/namespace:0.14.2'
         parameters: {
-          name: 'eh-{{context.azure.resourceNameHash}}'
+          name: 'evhns-{{context.azure.resourceNameHash}}'
           skuName: 'Standard'
           skuCapacity: 1
           disableLocalAuth: false

--- a/recipe-packs/azure/aks-recipepack.bicep
+++ b/recipe-packs/azure/aks-recipepack.bicep
@@ -30,12 +30,13 @@ param postgreSqlServerConfigurations array = []
 resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
   name: 'azure-avm'
   properties: {
+    // Azure resources that need globally unique names use a service prefix and a stable hash.
     recipes: {
       'Radius.Data/redisCaches': {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'redis-{{context.azure.resourceNameHash}}'
           skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
           highAvailability: 'Disabled'
           database: {
@@ -60,10 +61,10 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/cognitive-services/account:0.15.0'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'ai-{{context.azure.resourceNameHash}}'
           kind: 'OpenAI'
           sku: 'S0'
-          customSubDomainName: '{{context.resource.name}}'
+          customSubDomainName: 'ai-{{context.azure.resourceNameHash}}'
           disableLocalAuth: false
           publicNetworkAccess: 'Enabled'
           deployments: [
@@ -96,7 +97,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/search/search-service:0.12.2'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'search-{{context.azure.resourceNameHash}}'
           sku: 'basic'
           disableLocalAuth: false
           replicaCount: 1
@@ -117,7 +118,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/document-db/database-account:0.19.0'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'cosmos-{{context.azure.resourceNameHash}}'
           capabilitiesToAdd: [
             'EnableMongo'
           ]
@@ -146,7 +147,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/db-for-my-sql/flexible-server:0.10.3'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'mysql-{{context.azure.resourceNameHash}}'
           administratorLogin: '{{context.resource.properties.username}}'
           administratorLoginPassword: '{{context.resource.properties.password}}'
           skuName: 'Standard_B1ms'
@@ -182,7 +183,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/db-for-postgre-sql/flexible-server:0.15.2'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'postgres-{{context.azure.resourceNameHash}}'
           administratorLogin: '{{context.resource.properties.username}}'
           administratorLoginPassword: '{{context.resource.properties.password}}'
           authConfig: {
@@ -224,7 +225,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'sql-{{context.azure.resourceNameHash}}'
           administratorLogin: '{{context.resource.properties.username}}'
           administratorLoginPassword: '{{context.resource.properties.password}}'
           publicNetworkAccess: 'Enabled'
@@ -260,7 +261,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/service-bus/namespace:0.16.2'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'sb-{{context.azure.resourceNameHash}}'
           skuObject: {
             name: 'Standard'
           }
@@ -287,7 +288,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/event-hub/namespace:0.14.2'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'eh-{{context.azure.resourceNameHash}}'
           skuName: 'Standard'
           skuCapacity: 1
           disableLocalAuth: false
@@ -312,7 +313,7 @@ resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
         kind: 'bicep'
         source: 'mcr.microsoft.com/bicep/avm/res/storage/storage-account:0.32.1'
         parameters: {
-          name: '{{context.resource.name}}'
+          name: 'st{{context.azure.resourceNameHash}}'
           kind: 'StorageV2'
           skuName: 'Standard_LRS'
           allowBlobPublicAccess: false


### PR DESCRIPTION
## Summary

The Azure Recipe Pack passed raw Radius names to services that require globally unique names, so common names such as `redis` and `rabbitmq` failed with `NameInUse`.

This change gives all ten affected services a short provider-safe prefix followed by `context.azure.resourceNameHash`. The same Radius resource keeps its Azure name across redeployments, while resources in different Azure scopes receive different names.

This pack requires a Radius runtime that supports `context.azure.resourceNameHash`. Existing edge deployments may provision replacement Azure resources when they adopt the updated naming scheme.

## Validation

- Compiled the Azure Recipe Pack with the Radius Bicep extension.
- Confirmed all generated names meet the affected Azure services' character and length limits.

Depends on radius-project/radius#12616, which adds the `context.azure.resourceNameHash` expression this pack relies on.

Fixes radius-project/ai-extensions#128
